### PR TITLE
feat: add always-on PKCE support for all OAuth2 flows

### DIFF
--- a/packages/vestibule_google/src/vestibule_google.gleam
+++ b/packages/vestibule_google/src/vestibule_google.gleam
@@ -1,7 +1,7 @@
 import gleam/dict
 import gleam/dynamic/decode
 import gleam/json
-import gleam/option.{None, Some}
+import gleam/option.{type Option, None, Some}
 import gleam/string
 import gleam/uri
 
@@ -155,6 +155,7 @@ fn do_authorize_url(
 fn do_exchange_code(
   config: Config,
   code: String,
+  code_verifier: Option(String),
 ) -> Result(Credentials, AuthError(e)) {
   let assert Ok(site) = uri.parse("https://oauth2.googleapis.com")
   let assert Ok(redirect) = uri.parse(config.redirect_uri)
@@ -172,6 +173,7 @@ fn do_exchange_code(
       redirect,
     )
     |> request.set_header("accept", "application/json")
+  let req = append_code_verifier(req, code_verifier)
   case httpc.send(req) {
     Ok(response) -> parse_token_response(response.body)
     Error(_) ->
@@ -196,5 +198,23 @@ fn do_fetch_user(
       Error(error.NetworkError(
         reason: "Failed to connect to Google userinfo API",
       ))
+  }
+}
+
+/// Append code_verifier to the form-encoded request body when present.
+fn append_code_verifier(
+  req: request.Request(String),
+  code_verifier: Option(String),
+) -> request.Request(String) {
+  case code_verifier {
+    Some(verifier) -> {
+      let body = case req.body {
+        "" -> "code_verifier=" <> uri.percent_encode(verifier)
+        existing ->
+          existing <> "&code_verifier=" <> uri.percent_encode(verifier)
+      }
+      request.set_body(req, body)
+    }
+    None -> req
   }
 }

--- a/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
+++ b/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
@@ -6,18 +6,19 @@ pub fn main() -> Nil {
   startest.run(startest.default_config())
 }
 
-pub fn store_and_retrieve_state_test() {
+pub fn store_and_retrieve_state_and_verifier_test() {
   state_store.init()
   let state = "test-csrf-state-value"
-  let session_id = state_store.store(state)
+  let verifier = "test-pkce-code-verifier"
+  let session_id = state_store.store(state, verifier)
   state_store.retrieve(session_id)
   |> expect.to_be_ok()
-  |> expect.to_equal(state)
+  |> expect.to_equal(#(state, verifier))
 }
 
 pub fn retrieve_deletes_after_use_test() {
   state_store.init()
-  let session_id = state_store.store("one-time-state")
+  let session_id = state_store.store("one-time-state", "one-time-verifier")
   let _ = state_store.retrieve(session_id)
   state_store.retrieve(session_id)
   |> expect.to_be_error()

--- a/src/vestibule/authorization_request.gleam
+++ b/src/vestibule/authorization_request.gleam
@@ -1,0 +1,14 @@
+/// Represents the result of generating an authorization URL.
+///
+/// Contains all values needed for the OAuth2 authorization phase,
+/// including PKCE parameters that must be stored for the callback phase.
+pub type AuthorizationRequest {
+  AuthorizationRequest(
+    /// The authorization URL to redirect the user to.
+    url: String,
+    /// The CSRF state parameter (must be stored for validation).
+    state: String,
+    /// The PKCE code verifier (must be stored for token exchange).
+    code_verifier: String,
+  )
+}

--- a/src/vestibule/pkce.gleam
+++ b/src/vestibule/pkce.gleam
@@ -1,0 +1,25 @@
+/// PKCE (Proof Key for Code Exchange) utilities for OAuth2.
+///
+/// Implements RFC 7636 with S256 challenge method.
+/// PKCE prevents authorization code interception attacks.
+import gleam/bit_array
+import gleam/crypto
+
+/// Generate a cryptographically random code verifier.
+///
+/// Produces 32 bytes of random data, base64url-encoded without padding,
+/// resulting in a 43-character string conforming to RFC 7636.
+pub fn generate_verifier() -> String {
+  crypto.strong_random_bytes(32)
+  |> bit_array.base64_url_encode(False)
+}
+
+/// Compute the S256 code challenge from a code verifier.
+///
+/// Returns the SHA-256 hash of the verifier, base64url-encoded without padding,
+/// as specified by RFC 7636 Section 4.2.
+pub fn compute_challenge(verifier: String) -> String {
+  <<verifier:utf8>>
+  |> crypto.hash(crypto.Sha256, _)
+  |> bit_array.base64_url_encode(False)
+}

--- a/src/vestibule/strategy.gleam
+++ b/src/vestibule/strategy.gleam
@@ -1,3 +1,5 @@
+import gleam/option.{type Option}
+
 import vestibule/config.{type Config}
 import vestibule/credentials.{type Credentials}
 import vestibule/error.{type AuthError}
@@ -21,7 +23,9 @@ pub type Strategy(e) {
     authorize_url: fn(Config, List(String), String) ->
       Result(String, AuthError(e)),
     /// Exchange an authorization code for credentials.
-    exchange_code: fn(Config, String) -> Result(Credentials, AuthError(e)),
+    /// The third parameter is an optional PKCE code verifier.
+    exchange_code: fn(Config, String, Option(String)) ->
+      Result(Credentials, AuthError(e)),
     /// Fetch user info using the obtained credentials.
     /// Returns #(uid, user_info).
     fetch_user: fn(Credentials) -> Result(#(String, UserInfo), AuthError(e)),

--- a/test/vestibule/pkce_test.gleam
+++ b/test/vestibule/pkce_test.gleam
@@ -1,0 +1,42 @@
+import gleam/string
+import startest/expect
+import vestibule/pkce
+
+pub fn generate_verifier_produces_43_char_string_test() {
+  let verifier = pkce.generate_verifier()
+  // 32 bytes base64url-encoded without padding = 43 chars
+  string.length(verifier) |> expect.to_equal(43)
+}
+
+pub fn generate_verifier_produces_unique_values_test() {
+  let a = pkce.generate_verifier()
+  let b = pkce.generate_verifier()
+  { a != b } |> expect.to_be_true()
+}
+
+pub fn compute_challenge_produces_consistent_output_test() {
+  let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+  let challenge1 = pkce.compute_challenge(verifier)
+  let challenge2 = pkce.compute_challenge(verifier)
+  challenge1 |> expect.to_equal(challenge2)
+}
+
+pub fn compute_challenge_produces_base64url_string_test() {
+  let verifier = pkce.generate_verifier()
+  let challenge = pkce.compute_challenge(verifier)
+  // SHA-256 hash = 32 bytes, base64url-encoded without padding = 43 chars
+  string.length(challenge) |> expect.to_equal(43)
+}
+
+pub fn compute_challenge_differs_from_verifier_test() {
+  let verifier = pkce.generate_verifier()
+  let challenge = pkce.compute_challenge(verifier)
+  { verifier != challenge } |> expect.to_be_true()
+}
+
+pub fn compute_challenge_matches_rfc7636_example_test() {
+  // RFC 7636 Appendix B test vector
+  let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+  let challenge = pkce.compute_challenge(verifier)
+  challenge |> expect.to_equal("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+}

--- a/test/vestibule/registry_test.gleam
+++ b/test/vestibule/registry_test.gleam
@@ -11,7 +11,7 @@ fn test_strategy(name: String) -> Strategy(e) {
     default_scopes: [],
     token_url: "https://example.com/oauth/token",
     authorize_url: fn(_config, _scopes, _state) { Ok("https://example.com") },
-    exchange_code: fn(_config, _code) {
+    exchange_code: fn(_config, _code, _code_verifier) {
       Error(error.ConfigError(reason: "test"))
     },
     fetch_user: fn(_creds) { Error(error.ConfigError(reason: "test")) },

--- a/test/vestibule_test.gleam
+++ b/test/vestibule_test.gleam
@@ -4,6 +4,7 @@ import gleam/string
 import startest
 import startest/expect
 import vestibule
+import vestibule/authorization_request.{AuthorizationRequest}
 import vestibule/config
 import vestibule/credentials.{Credentials}
 import vestibule/error
@@ -28,7 +29,7 @@ fn test_strategy() -> Strategy(e) {
         <> state,
       )
     },
-    exchange_code: fn(_config, code) {
+    exchange_code: fn(_config, code, _code_verifier) {
       case code {
         "valid_code" ->
           Ok(
@@ -59,15 +60,20 @@ fn test_strategy() -> Strategy(e) {
   )
 }
 
-pub fn authorize_url_returns_url_and_state_test() {
+pub fn authorize_url_returns_authorization_request_test() {
   let strat = test_strategy()
   let conf = config.new("id", "secret", "http://localhost/cb")
   let result = vestibule.authorize_url(strat, conf)
-  let assert Ok(#(url, state)) = result
+  let assert Ok(AuthorizationRequest(url:, state:, code_verifier:)) = result
   // URL should contain the state
   { string.contains(url, state) } |> expect.to_be_true()
   // State should be non-empty
   { string.length(state) >= 43 } |> expect.to_be_true()
+  // Code verifier should be non-empty
+  { string.length(code_verifier) >= 43 } |> expect.to_be_true()
+  // URL should contain PKCE params
+  { string.contains(url, "code_challenge=") } |> expect.to_be_true()
+  { string.contains(url, "code_challenge_method=S256") } |> expect.to_be_true()
 }
 
 pub fn authorize_url_uses_config_scopes_when_present_test() {
@@ -75,7 +81,8 @@ pub fn authorize_url_uses_config_scopes_when_present_test() {
   let conf =
     config.new("id", "secret", "http://localhost/cb")
     |> config.with_scopes(["custom_scope"])
-  let assert Ok(#(url, _state)) = vestibule.authorize_url(strat, conf)
+  let assert Ok(AuthorizationRequest(url:, ..)) =
+    vestibule.authorize_url(strat, conf)
   { string.contains(url, "custom_scope") } |> expect.to_be_true()
   { string.contains(url, "default_scope") } |> expect.to_be_false()
 }
@@ -83,7 +90,8 @@ pub fn authorize_url_uses_config_scopes_when_present_test() {
 pub fn authorize_url_uses_default_scopes_when_config_empty_test() {
   let strat = test_strategy()
   let conf = config.new("id", "secret", "http://localhost/cb")
-  let assert Ok(#(url, _state)) = vestibule.authorize_url(strat, conf)
+  let assert Ok(AuthorizationRequest(url:, ..)) =
+    vestibule.authorize_url(strat, conf)
   { string.contains(url, "default_scope") } |> expect.to_be_true()
 }
 
@@ -92,7 +100,8 @@ pub fn handle_callback_succeeds_with_valid_params_test() {
   let conf = config.new("id", "secret", "http://localhost/cb")
   let state = "test_state_value"
   let params = dict.from_list([#("code", "valid_code"), #("state", state)])
-  let result = vestibule.handle_callback(strat, conf, params, state)
+  let result =
+    vestibule.handle_callback(strat, conf, params, state, "test_verifier")
   let assert Ok(auth) = result
   auth.uid |> expect.to_equal("user123")
   auth.provider |> expect.to_equal("test")
@@ -104,7 +113,8 @@ pub fn handle_callback_fails_on_state_mismatch_test() {
   let strat = test_strategy()
   let conf = config.new("id", "secret", "http://localhost/cb")
   let params = dict.from_list([#("code", "valid_code"), #("state", "wrong")])
-  let result = vestibule.handle_callback(strat, conf, params, "expected")
+  let result =
+    vestibule.handle_callback(strat, conf, params, "expected", "test_verifier")
   let _ = result |> expect.to_be_error()
   Nil
 }
@@ -114,7 +124,8 @@ pub fn handle_callback_fails_on_missing_code_test() {
   let conf = config.new("id", "secret", "http://localhost/cb")
   let state = "test_state"
   let params = dict.from_list([#("state", state)])
-  let result = vestibule.handle_callback(strat, conf, params, state)
+  let result =
+    vestibule.handle_callback(strat, conf, params, state, "test_verifier")
   let _ = result |> expect.to_be_error()
   Nil
 }


### PR DESCRIPTION
## Summary

- Adds always-on PKCE (Proof Key for Code Exchange, RFC 7636) to every OAuth2 authorization flow
- New `vestibule/pkce` module generates code verifier (32 bytes crypto random, base64url) and computes S256 challenge
- New `AuthorizationRequest` record replaces the `#(String, String)` tuple from `authorize_url`, bundling url + state + code_verifier
- `handle_callback` accepts the code_verifier and passes it through to the token exchange POST
- Strategy `exchange_code` signature updated: `fn(Config, String, Option(String))` — third param is optional code_verifier
- All three strategies (GitHub, Google, Microsoft) updated to include `code_verifier` in token exchange when present
- `vestibule_wisp` state store updated to persist `#(state, code_verifier)` tuple; middleware passes verifier through transparently
- Includes RFC 7636 Appendix B test vector validation

## Test plan

- [x] Root tests pass (31 tests)
- [x] vestibule_wisp tests pass (3 tests)
- [x] vestibule_google tests pass (6 tests)
- [x] vestibule_microsoft tests pass (6 tests)
- [x] New PKCE unit tests: verifier length, uniqueness, challenge consistency, RFC 7636 test vector
- [ ] Manual E2E test with example app against a real provider