### PR TITLE
feat: add token refresh utilities

### DIFF
--- a/packages/vestibule_google/src/vestibule_google.gleam
+++ b/packages/vestibule_google/src/vestibule_google.gleam
@@ -24,6 +24,7 @@ pub fn strategy() -> Strategy(e) {
   Strategy(
     provider: "google",
     default_scopes: ["openid", "profile", "email"],
+    token_url: "https://oauth2.googleapis.com/token",
     authorize_url: do_authorize_url,
     exchange_code: do_exchange_code,
     fetch_user: do_fetch_user,

--- a/packages/vestibule_microsoft/src/vestibule_microsoft.gleam
+++ b/packages/vestibule_microsoft/src/vestibule_microsoft.gleam
@@ -26,6 +26,7 @@ pub fn strategy() -> Strategy(e) {
   Strategy(
     provider: "microsoft",
     default_scopes: ["User.Read"],
+    token_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
     authorize_url: do_authorize_url,
     exchange_code: do_exchange_code,
     fetch_user: do_fetch_user,

--- a/src/vestibule.gleam
+++ b/src/vestibule.gleam
@@ -3,10 +3,18 @@
 /// Provides a consistent interface across OAuth2 identity providers
 /// using a two-phase flow: redirect to provider, then handle callback.
 import gleam/dict.{type Dict}
+import gleam/dynamic/decode
+import gleam/http
+import gleam/http/request
+import gleam/httpc
+import gleam/json
+import gleam/option.{None}
 import gleam/result
+import gleam/string
 
 import vestibule/auth.{type Auth, Auth}
 import vestibule/config.{type Config}
+import vestibule/credentials.{type Credentials, Credentials}
 import vestibule/error.{type AuthError}
 import vestibule/state
 import vestibule/strategy.{type Strategy}
@@ -80,4 +88,104 @@ pub fn handle_callback(
     credentials: credentials,
     extra: dict.new(),
   ))
+}
+
+/// Refresh an access token using a refresh token.
+///
+/// Sends a POST request to the strategy's token endpoint with the
+/// `refresh_token` grant type. Returns new credentials on success.
+pub fn refresh_token(
+  strategy: Strategy(e),
+  config: Config,
+  refresh_tok: String,
+) -> Result(Credentials, AuthError(e)) {
+  let body =
+    "grant_type=refresh_token"
+    <> "&refresh_token="
+    <> refresh_tok
+    <> "&client_id="
+    <> config.client_id
+    <> "&client_secret="
+    <> config.client_secret
+
+  let req_result =
+    request.to(strategy.token_url)
+    |> result.replace_error(error.ConfigError(
+      reason: "Invalid token URL: " <> strategy.token_url,
+    ))
+
+  use req <- result.try(req_result)
+
+  let req =
+    req
+    |> request.set_method(http.Post)
+    |> request.set_header("content-type", "application/x-www-form-urlencoded")
+    |> request.set_header("accept", "application/json")
+    |> request.set_body(body)
+
+  case httpc.send(req) {
+    Ok(response) -> parse_refresh_response(response.body)
+    Error(_) ->
+      Error(error.NetworkError(
+        reason: "Failed to connect to token endpoint: " <> strategy.token_url,
+      ))
+  }
+}
+
+/// Parse a token refresh response JSON into Credentials.
+///
+/// Handles both success responses and error responses from the provider.
+/// Exported for testing.
+pub fn parse_refresh_response(body: String) -> Result(Credentials, AuthError(e)) {
+  // Check for error response first
+  let error_decoder = {
+    use error_code <- decode.field("error", decode.string)
+    use description <- decode.field("error_description", decode.string)
+    decode.success(#(error_code, description))
+  }
+  case json.parse(body, error_decoder) {
+    Ok(#(code, description)) ->
+      Error(error.ProviderError(code: code, description: description))
+    _ -> parse_refresh_success(body)
+  }
+}
+
+fn parse_refresh_success(body: String) -> Result(Credentials, AuthError(e)) {
+  let decoder = {
+    use access_token <- decode.field("access_token", decode.string)
+    use token_type <- decode.field("token_type", decode.string)
+    use refresh_token_val <- decode.optional_field(
+      "refresh_token",
+      None,
+      decode.optional(decode.string),
+    )
+    use expires_in <- decode.optional_field(
+      "expires_in",
+      None,
+      decode.optional(decode.int),
+    )
+    use scope <- decode.optional_field(
+      "scope",
+      None,
+      decode.optional(decode.string),
+    )
+    let scopes = case scope {
+      option.Some(s) -> string.split(s, " ")
+      None -> []
+    }
+    decode.success(Credentials(
+      token: access_token,
+      refresh_token: refresh_token_val,
+      token_type: token_type,
+      expires_at: expires_in,
+      scopes: scopes,
+    ))
+  }
+  case json.parse(body, decoder) {
+    Ok(creds) -> Ok(creds)
+    _ ->
+      Error(error.CodeExchangeFailed(
+        reason: "Failed to parse token refresh response",
+      ))
+  }
 }

--- a/src/vestibule/strategy.gleam
+++ b/src/vestibule/strategy.gleam
@@ -14,6 +14,8 @@ pub type Strategy(e) {
     provider: String,
     /// Default scopes for this provider.
     default_scopes: List(String),
+    /// The provider's token endpoint URL, used for code exchange and token refresh.
+    token_url: String,
     /// Build the authorization URL to redirect the user to.
     /// Parameters: config, scopes, state.
     authorize_url: fn(Config, List(String), String) ->

--- a/src/vestibule/strategy/github.gleam
+++ b/src/vestibule/strategy/github.gleam
@@ -27,6 +27,7 @@ pub fn strategy() -> Strategy(e) {
   Strategy(
     provider: "github",
     default_scopes: ["user:email"],
+    token_url: "https://github.com/login/oauth/access_token",
     authorize_url: do_authorize_url,
     exchange_code: do_exchange_code,
     fetch_user: do_fetch_user,

--- a/test/vestibule/refresh_test.gleam
+++ b/test/vestibule/refresh_test.gleam
@@ -1,0 +1,90 @@
+import gleam/option.{None, Some}
+import startest/expect
+import vestibule
+import vestibule/credentials.{Credentials}
+import vestibule/error
+
+pub fn parse_refresh_response_success_with_all_fields_test() {
+  let body =
+    "{\"access_token\":\"new_access_token\",\"token_type\":\"Bearer\",\"refresh_token\":\"new_refresh_token\",\"expires_in\":3600,\"scope\":\"openid profile email\"}"
+  vestibule.parse_refresh_response(body)
+  |> expect.to_be_ok()
+  |> expect.to_equal(
+    Credentials(
+      token: "new_access_token",
+      refresh_token: Some("new_refresh_token"),
+      token_type: "Bearer",
+      expires_at: Some(3600),
+      scopes: ["openid", "profile", "email"],
+    ),
+  )
+}
+
+pub fn parse_refresh_response_success_minimal_test() {
+  let body = "{\"access_token\":\"token_abc\",\"token_type\":\"bearer\"}"
+  vestibule.parse_refresh_response(body)
+  |> expect.to_be_ok()
+  |> expect.to_equal(
+    Credentials(
+      token: "token_abc",
+      refresh_token: None,
+      token_type: "bearer",
+      expires_at: None,
+      scopes: [],
+    ),
+  )
+}
+
+pub fn parse_refresh_response_with_refresh_token_rotation_test() {
+  let body =
+    "{\"access_token\":\"rotated_access\",\"token_type\":\"Bearer\",\"refresh_token\":\"rotated_refresh\",\"expires_in\":7200,\"scope\":\"user:email\"}"
+  vestibule.parse_refresh_response(body)
+  |> expect.to_be_ok()
+  |> expect.to_equal(
+    Credentials(
+      token: "rotated_access",
+      refresh_token: Some("rotated_refresh"),
+      token_type: "Bearer",
+      expires_at: Some(7200),
+      scopes: ["user:email"],
+    ),
+  )
+}
+
+pub fn parse_refresh_response_error_invalid_grant_test() {
+  let body =
+    "{\"error\":\"invalid_grant\",\"error_description\":\"The refresh token has expired.\"}"
+  vestibule.parse_refresh_response(body)
+  |> expect.to_be_error()
+  |> expect.to_equal(error.ProviderError(
+    code: "invalid_grant",
+    description: "The refresh token has expired.",
+  ))
+}
+
+pub fn parse_refresh_response_error_invalid_client_test() {
+  let body =
+    "{\"error\":\"invalid_client\",\"error_description\":\"Client authentication failed.\"}"
+  vestibule.parse_refresh_response(body)
+  |> expect.to_be_error()
+  |> expect.to_equal(error.ProviderError(
+    code: "invalid_client",
+    description: "Client authentication failed.",
+  ))
+}
+
+pub fn parse_refresh_response_malformed_json_test() {
+  let body = "not valid json at all"
+  vestibule.parse_refresh_response(body)
+  |> expect.to_be_error()
+  |> expect.to_equal(error.CodeExchangeFailed(
+    reason: "Failed to parse token refresh response",
+  ))
+}
+
+pub fn parse_refresh_response_without_scope_has_empty_scopes_test() {
+  let body =
+    "{\"access_token\":\"tok\",\"token_type\":\"Bearer\",\"expires_in\":3600}"
+  let assert Ok(creds) = vestibule.parse_refresh_response(body)
+  creds.scopes |> expect.to_equal([])
+}

--- a/test/vestibule/registry_test.gleam
+++ b/test/vestibule/registry_test.gleam
@@ -9,6 +9,7 @@ fn test_strategy(name: String) -> Strategy(e) {
   Strategy(
     provider: name,
     default_scopes: [],
+    token_url: "https://example.com/oauth/token",
     authorize_url: fn(_config, _scopes, _state) { Ok("https://example.com") },
     exchange_code: fn(_config, _code) {
       Error(error.ConfigError(reason: "test"))

--- a/test/vestibule_test.gleam
+++ b/test/vestibule_test.gleam
@@ -19,6 +19,7 @@ fn test_strategy() -> Strategy(e) {
   Strategy(
     provider: "test",
     default_scopes: ["default_scope"],
+    token_url: "https://test.com/oauth/token",
     authorize_url: fn(_config, scopes, state) {
       Ok(
         "https://test.com/auth?scope="


### PR DESCRIPTION
## Summary

- Adds `vestibule.refresh_token/3` to the core module for refreshing expired access tokens
- Adds `token_url: String` field to the `Strategy` record, storing each provider's token endpoint
- The refresh function POSTs to `strategy.token_url` with `grant_type=refresh_token` per RFC 6749 Section 6
- Includes `parse_refresh_response` for standard OAuth2 token response parsing (handles success, error, and malformed responses)
- All three strategies updated with their token URLs:
  - GitHub: `https://github.com/login/oauth/access_token`
  - Google: `https://oauth2.googleapis.com/token`
  - Microsoft: `https://login.microsoftonline.com/common/oauth2/v2.0/token`
- 7 new tests covering refresh response parsing (success, minimal, rotation, errors, malformed)

## Test plan

- [x] Root tests pass (32 tests, 7 new)
- [x] vestibule_wisp tests pass (3 tests)
- [x] vestibule_google tests pass (6 tests)
- [x] vestibule_microsoft tests pass (6 tests)
- [ ] Manual E2E test: refresh a Google or Microsoft token