### PR TITLE
fix(vestibule_microsoft): stop using UPN as email fallback

### DIFF
--- a/packages/vestibule_microsoft/src/vestibule_microsoft.gleam
+++ b/packages/vestibule_microsoft/src/vestibule_microsoft.gleam
@@ -102,10 +102,7 @@ pub fn parse_user_response(
       None,
       decode.optional(decode.string),
     )
-    let email = case mail {
-      Some(_) -> mail
-      None -> Some(upn)
-    }
+    let email = mail
     let image = case email {
       Some(addr) -> Some(gravatar_url(addr))
       None -> None

--- a/packages/vestibule_microsoft/test/vestibule_microsoft_test.gleam
+++ b/packages/vestibule_microsoft/test/vestibule_microsoft_test.gleam
@@ -70,9 +70,12 @@ pub fn parse_user_response_minimal_test() {
   let assert Ok(#(uid, info)) = vestibule_microsoft.parse_user_response(body)
   uid |> expect.to_equal("abc-123")
   info.name |> expect.to_equal(None)
-  info.email |> expect.to_equal(Some("user@example.com"))
+  // UPN is not a verified email, so email should be None
+  info.email |> expect.to_equal(None)
   info.nickname |> expect.to_equal(Some("user@example.com"))
   info.description |> expect.to_equal(None)
+  // No gravatar when no verified email
+  info.image |> expect.to_equal(None)
 }
 
 pub fn parse_user_response_mail_preferred_over_upn_test() {


### PR DESCRIPTION
## Summary
- Microsoft `userPrincipalName` is not a verified email address — guest accounts can have UPNs like `attacker_company.com#EXT#@tenant.onmicrosoft.com`
- When the `mail` field is absent, `email` is now set to `None` instead of falling back to UPN
- Gravatar URL is also `None` when no verified email exists
- UPN remains available in the `nickname` field

Closes #21

## Test plan
- [x] All 6 vestibule_microsoft tests pass
- [x] `gleam check` passes