### PR TITLE
fix(vestibule_wisp): HTML-escape error messages in error page

### DIFF
--- a/packages/vestibule_wisp/src/vestibule_wisp.gleam
+++ b/packages/vestibule_wisp/src/vestibule_wisp.gleam
@@ -1,5 +1,6 @@
 import gleam/dict
 import gleam/result
+import gleam/string
 import wisp.{type Request, type Response}
 
 import vestibule
@@ -131,12 +132,22 @@ fn error_response(err: error.AuthError(e)) -> Response {
     error.ConfigError(reason:) -> "Configuration error: " <> reason
     error.Custom(_) -> "Custom provider error"
   }
+  let safe_message = html_escape(message)
   wisp.html_response("<html>
 <head><title>Authentication Error</title></head>
 <body style=\"font-family: system-ui, sans-serif; max-width: 600px; margin: 80px auto;\">
   <h1>Authentication Failed</h1>
-  <p style=\"color: #c0392b;\">" <> message <> "</p>
+  <p style=\"color: #c0392b;\">" <> safe_message <> "</p>
   <a href=\"/\">Try again</a>
 </body>
 </html>", 400)
+}
+
+fn html_escape(text: String) -> String {
+  text
+  |> string.replace("&", "&amp;")
+  |> string.replace("<", "&lt;")
+  |> string.replace(">", "&gt;")
+  |> string.replace("\"", "&quot;")
+  |> string.replace("'", "&#x27;")
 }

--- a/packages/vestibule_wisp/src/vestibule_wisp/state_store.gleam
+++ b/packages/vestibule_wisp/src/vestibule_wisp/state_store.gleam
@@ -22,11 +22,7 @@ pub fn init_named(name: String) -> StateStore {
 }
 
 /// Store a CSRF state value and PKCE code verifier, returning a session ID.
-pub fn store(
-  table: StateStore,
-  state: String,
-  code_verifier: String,
-) -> String {
+pub fn store(table: StateStore, state: String, code_verifier: String) -> String {
   let session_id =
     crypto.strong_random_bytes(16)
     |> bit_array.base64_url_encode(False)

--- a/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
+++ b/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
@@ -18,7 +18,8 @@ pub fn store_and_retrieve_state_and_verifier_test() {
 
 pub fn retrieve_deletes_after_use_test() {
   let table = state_store.init_named("test_delete_after_use")
-  let session_id = state_store.store(table, "one-time-state", "one-time-verifier")
+  let session_id =
+    state_store.store(table, "one-time-state", "one-time-verifier")
   let _ = state_store.retrieve(table, session_id)
   state_store.retrieve(table, session_id)
   |> expect.to_be_error()


### PR DESCRIPTION
## Summary
- Error messages from OAuth providers were embedded in the HTML error response without escaping
- A malicious provider (or MITM) returning `<script>alert(1)</script>` in `error_description` could execute arbitrary JavaScript
- Added `html_escape` function that escapes `&`, `<`, `>`, `"`, and `'`
- Applied to all error messages before embedding in the response

Closes #22

## Test plan
- [x] All 3 vestibule_wisp tests pass
- [x] `gleam check` passes