### PR TITLE
fix(vestibule_apple): use random cache key for ID token cache

### DIFF
--- a/packages/vestibule_apple/src/vestibule_apple.gleam
+++ b/packages/vestibule_apple/src/vestibule_apple.gleam
@@ -48,8 +48,8 @@ import vestibule/error.{type AuthError}
 import vestibule/strategy.{type Strategy, Strategy}
 import vestibule/user_info
 import vestibule_apple/id_token_cache.{type IdTokenCache}
-import vestibule_apple/jwt
 import vestibule_apple/jwks.{type JwksCache}
+import vestibule_apple/jwt
 import ywt/claim
 import ywt/verify_key.{type VerifyKey}
 

--- a/packages/vestibule_apple/src/vestibule_apple/id_token_cache.gleam
+++ b/packages/vestibule_apple/src/vestibule_apple/id_token_cache.gleam
@@ -3,35 +3,61 @@
 ///
 /// Apple's token response includes an `id_token` JWT that contains user info,
 /// but the Strategy type's fetch_user only receives Credentials. This cache
-/// bridges the gap by storing the id_token during exchange_code, keyed by
-/// the access_token, so fetch_user can retrieve and decode it.
+/// bridges the gap by storing the id_token during exchange_code so fetch_user
+/// can retrieve and decode it.
 ///
-/// Security: Uses bravo with Protected access (only the owning process can
-/// write) and atomic `uset.take` for one-time retrieval (no TOCTOU race).
+/// Security: Uses a cryptographically random cache key (not the access token)
+/// to prevent cache manipulation by anyone who obtains the access token.
+/// A Private key-mapping table ensures only the owning process can resolve
+/// access tokens to cache keys. Uses atomic `uset.take` for one-time
+/// retrieval (no TOCTOU race).
+import gleam/bit_array
+import gleam/crypto
+
 import bravo
 import bravo/uset.{type USet}
 
-/// The cache table type. Stores (access_token -> id_token) mappings.
-pub type IdTokenCache =
-  USet(String, String)
+/// The cache table type. Stores (random_key -> id_token) mappings.
+pub type IdTokenCache {
+  IdTokenCache(
+    /// Stores id_token data keyed by random cache key.
+    tokens: USet(String, String),
+    /// Maps access_token -> random cache key. Private access so only
+    /// the owning process can read/write.
+    keys: USet(String, String),
+  )
+}
 
 /// Initialize the ID token cache. Call once at application startup.
 /// Returns the cache handle needed by store/retrieve.
 pub fn init() -> IdTokenCache {
-  let assert Ok(table) =
+  let assert Ok(tokens) =
     uset.new(name: "vestibule_apple_id_tokens", access: bravo.Protected)
-  table
+  let assert Ok(keys) =
+    uset.new(name: "vestibule_apple_id_token_keys", access: bravo.Private)
+  IdTokenCache(tokens: tokens, keys: keys)
 }
 
 /// Initialize a named ID token cache. Useful for testing with isolated tables.
 pub fn init_named(name: String) -> IdTokenCache {
-  let assert Ok(table) = uset.new(name: name, access: bravo.Protected)
-  table
+  let assert Ok(tokens) =
+    uset.new(name: name <> "_tokens", access: bravo.Protected)
+  let assert Ok(keys) = uset.new(name: name <> "_keys", access: bravo.Private)
+  IdTokenCache(tokens: tokens, keys: keys)
 }
 
-/// Store an ID token, keyed by access token.
+/// Generate a cryptographically random cache key.
+fn generate_cache_key() -> String {
+  crypto.strong_random_bytes(32)
+  |> bit_array.base64_url_encode(False)
+}
+
+/// Store an ID token under a random cache key, mapped from the access token.
+/// Returns Nil.
 pub fn store(cache: IdTokenCache, access_token: String, id_token: String) -> Nil {
-  let _ = uset.insert(into: cache, key: access_token, value: id_token)
+  let cache_key = generate_cache_key()
+  let _ = uset.insert(into: cache.tokens, key: cache_key, value: id_token)
+  let _ = uset.insert(into: cache.keys, key: access_token, value: cache_key)
   Nil
 }
 
@@ -42,8 +68,15 @@ pub fn retrieve(
   cache: IdTokenCache,
   access_token: String,
 ) -> Result(String, Nil) {
-  case uset.take(from: cache, at: access_token) {
-    Ok(value) -> Ok(value)
+  // Look up the random cache key from the access token (Private table)
+  case uset.take(from: cache.keys, at: access_token) {
+    Ok(cache_key) -> {
+      // Use the random cache key to retrieve the id_token
+      case uset.take(from: cache.tokens, at: cache_key) {
+        Ok(value) -> Ok(value)
+        Error(_) -> Error(Nil)
+      }
+    }
     Error(_) -> Error(Nil)
   }
 }

--- a/packages/vestibule_apple/test/vestibule_apple_security_test.gleam
+++ b/packages/vestibule_apple/test/vestibule_apple_security_test.gleam
@@ -9,8 +9,8 @@ import gleam/time/duration
 import startest
 import startest/expect
 import vestibule_apple
-import vestibule_apple/jwt
 import vestibule_apple/jwks
+import vestibule_apple/jwt
 import ywt/claim
 import ywt/verify_key
 


### PR DESCRIPTION
## Summary
- The ID token cache was using the access token as the cache key, allowing anyone with the token to manipulate the cache
- Replaced with a two-table architecture:
  - **tokens** (Protected): maps random 32-byte cache keys to ID token data
  - **keys** (Private): maps access tokens to cache keys, readable only by the owning process
- Random keys use `crypto.strong_random_bytes(32)` with base64url encoding (same pattern as CSRF state generation)
- Public API unchanged — `store()` and `retrieve()` signatures remain the same

Closes #23

## Test plan
- [x] All 20 vestibule_apple tests pass
- [x] `gleam check` passes