### PR TITLE
chore: security fixes, opaque public types, docs sweep

### DIFF
--- a/.changes/unreleased/vestibule-Changed-20260516-005119.yaml
+++ b/.changes/unreleased/vestibule-Changed-20260516-005119.yaml
@@ -1,0 +1,4 @@
+project: vestibule
+kind: Changed
+body: 'Public types `Strategy`, `UserResult`, `ExchangeResult`, and `AuthorizationRequest` are now opaque. Construct via `strategy.new`, `strategy.user_result`, `strategy.exchange_result`, and `authorization_request.new`; read fields via the accessor functions on each module.'
+time: 2026-05-16T00:51:19.363143+00:00

--- a/.changes/unreleased/vestibule-Security-20260516-005120.yaml
+++ b/.changes/unreleased/vestibule-Security-20260516-005120.yaml
@@ -1,0 +1,4 @@
+project: vestibule
+kind: Security
+body: 'Documented PKCE, state, JWT verification, and the OIDC nonce gap in the root README. No behavior change.'
+time: 2026-05-16T00:51:20.369312+00:00

--- a/.changes/unreleased/vestibule_apple-Changed-20260516-005121.yaml
+++ b/.changes/unreleased/vestibule_apple-Changed-20260516-005121.yaml
@@ -1,0 +1,4 @@
+project: vestibule_apple
+kind: Changed
+body: '`AppleCache` and `JwksCache` are now opaque. Use `vestibule_apple.init` / `try_init` / `try_init_named` to construct an `AppleCache`; internal callers no longer access `jwks` directly.'
+time: 2026-05-16T00:51:21.375354+00:00

--- a/.changes/unreleased/vestibule_google-Changed-20260516-005122.yaml
+++ b/.changes/unreleased/vestibule_google-Changed-20260516-005122.yaml
@@ -1,0 +1,4 @@
+project: vestibule_google
+kind: Changed
+body: 'Provider strategy now uses the opaque `strategy.new` / `strategy.user_result` / `strategy.exchange_credentials` constructors and accessors. No behavior change.'
+time: 2026-05-16T00:51:22.381762+00:00

--- a/.changes/unreleased/vestibule_microsoft-Changed-20260516-005124.yaml
+++ b/.changes/unreleased/vestibule_microsoft-Changed-20260516-005124.yaml
@@ -1,0 +1,4 @@
+project: vestibule_microsoft
+kind: Changed
+body: 'Provider strategy now uses the opaque `strategy.new` / `strategy.user_result` / `strategy.exchange_credentials` constructors and accessors. No behavior change.'
+time: 2026-05-16T00:51:24.392163+00:00

--- a/.changes/unreleased/vestibule_microsoft-Fixed-20260516-005123.yaml
+++ b/.changes/unreleased/vestibule_microsoft-Fixed-20260516-005123.yaml
@@ -1,0 +1,4 @@
+project: vestibule_microsoft
+kind: Fixed
+body: 'Refresh-token responses now use `RequiredScope(" ")` to match the exchange-code behavior. Previously `OptionalScope` would silently return `[]` if Microsoft omitted `scope` on refresh.'
+time: 2026-05-16T00:51:23.386922+00:00

--- a/.changes/unreleased/vestibule_wisp-Changed-20260516-005126.yaml
+++ b/.changes/unreleased/vestibule_wisp-Changed-20260516-005126.yaml
@@ -1,0 +1,4 @@
+project: vestibule_wisp
+kind: Changed
+body: 'Middleware now reads `AuthorizationRequest` fields through the new `authorization_request.url` / `state` / `code_verifier` accessors.'
+time: 2026-05-16T00:51:26.404428+00:00

--- a/.changes/unreleased/vestibule_wisp-Security-20260516-005125.yaml
+++ b/.changes/unreleased/vestibule_wisp-Security-20260516-005125.yaml
@@ -1,0 +1,4 @@
+project: vestibule_wisp
+kind: Security
+body: 'State comparison in `callback_phase` now uses `state.validate` (constant-time) instead of `==`, closing a timing side-channel on CSRF token validation.'
+time: 2026-05-16T00:51:25.398675+00:00

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ case wisp.path_segments(req), req.method {
       // auth.uid, auth.info.name, auth.info.email
       wisp.redirect("/dashboard")
     })
+  _, _ -> wisp.not_found()
 }
 ```
 
@@ -189,6 +190,45 @@ Discover OpenID Connect providers from their issuer URL:
 ```gleam
 let assert Ok(strategy) = oidc.discover("https://accounts.google.com")
 ```
+
+## Security
+
+Vestibule implements the OAuth 2.0 / OIDC pieces that protect against
+common attacks, but a few responsibilities remain with the consuming app.
+
+**Built in**
+
+- **PKCE (RFC 7636)** — every authorization request gets a 256-bit
+  `code_verifier` and an `S256` `code_challenge`. Stored verifiers must
+  be sent with the token exchange.
+- **CSRF state** — every request gets a 256-bit base64url state token.
+  `state.validate` does a constant-time comparison and rejects empty
+  values. Validation runs before any provider response detail is surfaced.
+- **HTTPS enforcement** — production redirect URIs and OIDC issuers
+  must use HTTPS. `http://localhost` and `http://127.0.0.1` are
+  permitted for development only.
+- **JWT signature verification (Apple)** — Apple ID tokens are
+  verified against Apple's published JWKS (ES256) and validated for
+  `iss`, `aud`, and `exp` with a 60-second clock skew.
+- **Verified-email gating (OIDC, Google, Apple)** — `UserInfo.email`
+  is only populated when the provider reports `email_verified`.
+
+**Caller responsibilities**
+
+- **Persist `state` and `code_verifier`** server-side, bound to the
+  user's session, with a short TTL. Reject callbacks that are missing
+  either, and **delete both after a successful callback** so they
+  cannot be replayed. The `vestibule_wisp` middleware handles this
+  via single-use ETS entries.
+- **Redact `Credentials` and `Auth`** in logs and error reports.
+  Access tokens, refresh tokens, and ID tokens are bearer credentials —
+  treat them like passwords.
+- **Cookie-secret rotation** invalidates in-flight OAuth flows that
+  used the signed session cookie. Time rotations accordingly.
+- **OIDC `nonce`** is not currently generated or validated by the
+  discover-built strategy. If you need id_token replay protection
+  beyond PKCE, validate the `nonce` yourself when consuming the
+  `id_token` artifact returned in `ExchangeResult`.
 
 ## API Notes
 

--- a/packages/vestibule_apple/README.md
+++ b/packages/vestibule_apple/README.md
@@ -33,6 +33,28 @@ let strategy = vestibule_apple.strategy(apple)
 `try_init()` returns `Error(JwksCacheInitFailed(_))` when the JWKS cache cannot
 be initialized, including duplicate cache initialization.
 
+## Default scopes
+
+`name email`. Override with `config.with_scopes`. Apple delivers `name`
+and `email` only on the **first** consent, in the form-post callback.
+
+## Apple Developer portal setup
+
+1. Sign in at <https://developer.apple.com/account>.
+2. **Certificates, IDs & Profiles → Identifiers**:
+   - Create an **App ID** for your app, enable the
+     *Sign In with Apple* capability.
+   - Create a **Services ID** — this is your OAuth `client_id`.
+     Enable *Sign In with Apple*, add your domain, and register the
+     **return URL** (e.g. `https://example.com/auth/apple/callback`).
+     Apple does **not** allow `localhost` or `http://` callbacks.
+3. **Keys → register a new key**, enable *Sign In with Apple*, associate
+   it with your App ID, download the `.p8` private key (one-time
+   download). Note the **Key ID**.
+4. Note your **Team ID** (top-right of the developer portal).
+5. Use these to generate the signed JWT `client_secret` (see below).
+   Tracking issue: [#43](https://github.com/tylerbutler/vestibule/issues/43).
+
 ## Client-secret JWT setup
 
 Apple does not use a static client secret. The `client_secret` value in your

--- a/packages/vestibule_apple/src/vestibule_apple.gleam
+++ b/packages/vestibule_apple/src/vestibule_apple.gleam
@@ -1,32 +1,32 @@
-/// Apple Sign In strategy for vestibule.
-///
-/// Apple's OAuth implementation has several key differences from standard providers:
-///
-/// - **No userinfo endpoint**: User info is extracted from the `id_token` JWT
-///   in the token response rather than from a separate API call.
-/// - **`response_mode=form_post`**: Apple sends the callback as a POST with
-///   form data. The vestibule core handles extracting callback params, so this
-///   strategy just adds the parameter to the authorization URL.
-/// - **Client secret is a JWT**: Apple requires the client_secret to be a signed
-///   JWT. The caller is responsible for generating this JWT and providing it in
-///   the Config. This strategy passes it through to the token endpoint.
-/// - **User info only on first auth**: Apple only sends the full user object
-///   (with name) on the first authorization. Subsequent authorizations only
-///   include `sub` and `email` in the ID token.
-/// - **JWT signature verification**: ID tokens are verified against Apple's
-///   published JWKS keys using ES256.
-///
-/// ## Setup
-///
-/// Call `vestibule_apple.init()` once per VM at application startup to
-/// initialize caches, then use `vestibule_apple.strategy()` to create the
-/// strategy. Use `try_init()` if startup code needs to handle duplicate cache
-/// initialization without panicking.
-///
-/// ```gleam
-/// let apple = vestibule_apple.init()
-/// let strategy = vestibule_apple.strategy(apple)
-/// ```
+//// Apple Sign In strategy for vestibule.
+////
+//// Apple's OAuth implementation has several key differences from standard providers:
+////
+//// - **No userinfo endpoint**: User info is extracted from the `id_token` JWT
+////   in the token response rather than from a separate API call.
+//// - **`response_mode=form_post`**: Apple sends the callback as a POST with
+////   form data. The vestibule core handles extracting callback params, so this
+////   strategy just adds the parameter to the authorization URL.
+//// - **Client secret is a JWT**: Apple requires the client_secret to be a signed
+////   JWT. The caller is responsible for generating this JWT and providing it in
+////   the Config. This strategy passes it through to the token endpoint.
+//// - **User info only on first auth**: Apple only sends the full user object
+////   (with name) on the first authorization. Subsequent authorizations only
+////   include `sub` and `email` in the ID token.
+//// - **JWT signature verification**: ID tokens are verified against Apple's
+////   published JWKS keys using ES256.
+////
+//// ## Setup
+////
+//// Call `vestibule_apple.init()` once per VM at application startup to
+//// initialize caches, then use `vestibule_apple.strategy()` to create the
+//// strategy. Use `try_init()` if startup code needs to handle duplicate cache
+//// initialization without panicking.
+////
+//// ```gleam
+//// let apple = vestibule_apple.init()
+//// let strategy = vestibule_apple.strategy(apple)
+//// ```
 import gleam/dict
 import gleam/dynamic
 import gleam/dynamic/decode
@@ -50,9 +50,7 @@ import vestibule/config.{type Config}
 import vestibule/credentials.{type Credentials, Credentials}
 import vestibule/error.{type AuthError}
 import vestibule/provider_support
-import vestibule/strategy.{
-  type ExchangeResult, type Strategy, type UserResult, Strategy, UserResult,
-}
+import vestibule/strategy.{type ExchangeResult, type Strategy, type UserResult}
 import vestibule/user_info
 import vestibule_apple/jwks.{type JwksCache}
 import vestibule_apple/jwt
@@ -60,8 +58,10 @@ import ywt/claim
 import ywt/verify_key.{type VerifyKey}
 
 /// Holds the JWKS cache used for Apple ID token signature verification.
-/// Returned by `init()` and required by `strategy()`.
-pub type AppleCache {
+/// Returned by `init()` and required by `strategy()`. Construction and field
+/// access are intentionally opaque so the cache backing store can change
+/// without breaking consumers.
+pub opaque type AppleCache {
   AppleCache(jwks: JwksCache)
 }
 
@@ -113,7 +113,7 @@ pub fn try_init_named(prefix: String) -> Result(AppleCache, AppleInitError) {
 /// ID tokens are verified against Apple's published JWKS keys with
 /// claim validation for issuer, audience, and expiration.
 pub fn strategy(apple: AppleCache) -> Strategy(e) {
-  Strategy(
+  strategy.new(
     provider: "apple",
     default_scopes: ["name", "email"],
     authorize_url: do_authorize_url,
@@ -398,7 +398,7 @@ fn do_refresh_token(
     Ok(response) -> {
       use body <- result.try(provider_support.check_response_status(response))
       use exchange <- result.try(parse_token_response(body))
-      Ok(exchange.credentials)
+      Ok(strategy.exchange_credentials(exchange))
     }
     Error(_) ->
       Error(error.NetworkError(
@@ -415,7 +415,7 @@ fn do_fetch_user(
   // Apple has no userinfo endpoint. User info comes from the id_token JWT
   // returned as an exchange artifact.
   use artifact <- result.try(
-    dict.get(exchange.artifacts, "id_token")
+    dict.get(strategy.exchange_artifacts(exchange), "id_token")
     |> result.replace_error(error.UserInfoFailed(
       reason: "No Apple ID token found in exchange artifacts.",
     )),
@@ -432,5 +432,5 @@ fn do_fetch_user(
     keys,
     config.client_id(cfg),
   ))
-  Ok(UserResult(uid: uid, info: info, extra: dict.new()))
+  Ok(strategy.user_result(uid: uid, info: info, extra: dict.new()))
 }

--- a/packages/vestibule_apple/src/vestibule_apple/jwks.gleam
+++ b/packages/vestibule_apple/src/vestibule_apple/jwks.gleam
@@ -1,8 +1,8 @@
-/// Apple JWKS (JSON Web Key Set) fetching and caching.
-///
-/// Fetches Apple's public keys from `https://appleid.apple.com/auth/keys`
-/// and caches them in a bravo ETS table for reuse. Keys are used to verify
-/// the signature of Apple's ID token JWTs.
+//// Apple JWKS (JSON Web Key Set) fetching and caching.
+////
+//// Fetches Apple's public keys from `https://appleid.apple.com/auth/keys`
+//// and caches them in a bravo ETS table for reuse. Keys are used to verify
+//// the signature of Apple's ID token JWTs.
 import bravo
 import bravo/uset.{type USet}
 import gleam/http/request
@@ -18,8 +18,12 @@ import ywt/verify_key.{type VerifyKey}
 const apple_jwks_url = "https://appleid.apple.com/auth/keys"
 
 /// Opaque cache for Apple's JWKS keys.
-pub type JwksCache =
-  USet(String, List(VerifyKey))
+///
+/// Backed by a bravo `USet` ETS table, but the underlying storage is hidden
+/// so the dependency can be swapped without breaking consumers.
+pub opaque type JwksCache {
+  JwksCache(table: USet(String, List(VerifyKey)))
+}
 
 const cache_key = "apple_jwks"
 
@@ -51,7 +55,7 @@ pub fn try_init() -> Result(JwksCache, JwksCacheError) {
 /// exists or cannot be created.
 pub fn try_init_named(name: String) -> Result(JwksCache, JwksCacheError) {
   case uset.new(name: name, access: bravo.Protected) {
-    Ok(table) -> Ok(table)
+    Ok(table) -> Ok(JwksCache(table: table))
     Error(_) -> Error(JwksTableCreateFailed)
   }
 }
@@ -59,11 +63,11 @@ pub fn try_init_named(name: String) -> Result(JwksCache, JwksCacheError) {
 /// Get Apple's public verification keys, using cached keys if available.
 /// Falls back to fetching from Apple's JWKS endpoint.
 pub fn get_keys(cache: JwksCache) -> Result(List(VerifyKey), AuthError(e)) {
-  case uset.lookup(from: cache, at: cache_key) {
+  case uset.lookup(from: cache.table, at: cache_key) {
     Ok(keys) -> Ok(keys)
     Error(_) -> {
       use keys <- result.try(fetch_keys())
-      let _ = uset.insert(into: cache, key: cache_key, value: keys)
+      let _ = uset.insert(into: cache.table, key: cache_key, value: keys)
       Ok(keys)
     }
   }
@@ -72,7 +76,7 @@ pub fn get_keys(cache: JwksCache) -> Result(List(VerifyKey), AuthError(e)) {
 /// Force refresh the cached keys from Apple's endpoint.
 pub fn refresh_keys(cache: JwksCache) -> Result(List(VerifyKey), AuthError(e)) {
   use keys <- result.try(fetch_keys())
-  let _ = uset.insert(into: cache, key: cache_key, value: keys)
+  let _ = uset.insert(into: cache.table, key: cache_key, value: keys)
   Ok(keys)
 }
 

--- a/packages/vestibule_apple/src/vestibule_apple/jwt.gleam
+++ b/packages/vestibule_apple/src/vestibule_apple/jwt.gleam
@@ -1,8 +1,8 @@
-/// JWT verification using ywt_core with a custom Erlang FFI backend.
-///
-/// This replaces ywt_erlang to avoid an OTP 27 compatibility issue in
-/// its EC key generation. We only need verification (not key generation)
-/// for production use, plus HMAC signing for tests.
+//// JWT verification using ywt_core with a custom Erlang FFI backend.
+////
+//// This replaces ywt_erlang to avoid an OTP 27 compatibility issue in
+//// its EC key generation. We only need verification (not key generation)
+//// for production use, plus HMAC signing for tests.
 import gleam/crypto
 import gleam/dynamic/decode.{type Decoder}
 import gleam/json

--- a/packages/vestibule_apple/test/vestibule_apple_test.gleam
+++ b/packages/vestibule_apple/test/vestibule_apple_test.gleam
@@ -4,6 +4,7 @@ import gleam/option.{None, Some}
 import startest
 import startest/expect
 import vestibule/config
+import vestibule/strategy
 import vestibule/credentials.{Credentials}
 import vestibule_apple
 import vestibule_apple/jwks
@@ -15,7 +16,9 @@ pub fn main() -> Nil {
 // --- Strategy construction ---
 
 fn test_apple_cache(name: String) -> vestibule_apple.AppleCache {
-  vestibule_apple.AppleCache(jwks: jwks.init_named("apple_test_jwks_" <> name))
+  let assert Ok(cache) =
+    vestibule_apple.try_init_named("apple_test_" <> name)
+  cache
 }
 
 pub fn jwks_try_init_named_returns_error_for_duplicate_table_test() {
@@ -36,12 +39,12 @@ pub fn apple_try_init_named_returns_error_for_duplicate_cache_test() {
 
 pub fn strategy_provider_test() {
   let s = vestibule_apple.strategy(test_apple_cache("provider"))
-  s.provider |> expect.to_equal("apple")
+  strategy.provider(s) |> expect.to_equal("apple")
 }
 
 pub fn strategy_default_scopes_test() {
   let s = vestibule_apple.strategy(test_apple_cache("scopes"))
-  s.default_scopes |> expect.to_equal(["name", "email"])
+  strategy.default_scopes(s) |> expect.to_equal(["name", "email"])
 }
 
 // --- Token response parsing ---
@@ -50,7 +53,7 @@ pub fn parse_token_response_success_test() {
   let body =
     "{\"access_token\":\"a1b2c3.test_access_token\",\"token_type\":\"Bearer\",\"expires_in\":3600,\"refresh_token\":\"r4e5f6.test_refresh\",\"id_token\":\"header.payload.signature\"}"
   let assert Ok(exchange) = vestibule_apple.parse_token_response(body)
-  exchange.credentials
+  strategy.exchange_credentials(exchange)
   |> expect.to_equal(
     Credentials(
       token: "a1b2c3.test_access_token",
@@ -60,7 +63,7 @@ pub fn parse_token_response_success_test() {
       scopes: [],
     ),
   )
-  let assert Ok(id_token) = dict.get(exchange.artifacts, "id_token")
+  let assert Ok(id_token) = dict.get(strategy.exchange_artifacts(exchange), "id_token")
   decode.run(id_token, decode.string)
   |> expect.to_equal(Ok("header.payload.signature"))
 }
@@ -69,9 +72,9 @@ pub fn parse_token_response_without_refresh_token_test() {
   let body =
     "{\"access_token\":\"test_token\",\"token_type\":\"Bearer\",\"expires_in\":3600,\"id_token\":\"h.p.s\"}"
   let assert Ok(exchange) = vestibule_apple.parse_token_response(body)
-  exchange.credentials.token |> expect.to_equal("test_token")
-  exchange.credentials.refresh_token |> expect.to_equal(None)
-  let assert Ok(id_token) = dict.get(exchange.artifacts, "id_token")
+  strategy.exchange_credentials(exchange).token |> expect.to_equal("test_token")
+  strategy.exchange_credentials(exchange).refresh_token |> expect.to_equal(None)
+  let assert Ok(id_token) = dict.get(strategy.exchange_artifacts(exchange), "id_token")
   decode.run(id_token, decode.string) |> expect.to_equal(Ok("h.p.s"))
 }
 
@@ -79,15 +82,15 @@ pub fn parse_token_response_without_id_token_test() {
   let body =
     "{\"access_token\":\"test_token\",\"token_type\":\"Bearer\",\"expires_in\":3600}"
   let assert Ok(exchange) = vestibule_apple.parse_token_response(body)
-  exchange.credentials.token |> expect.to_equal("test_token")
-  dict.get(exchange.artifacts, "id_token") |> expect.to_be_error()
+  strategy.exchange_credentials(exchange).token |> expect.to_equal("test_token")
+  dict.get(strategy.exchange_artifacts(exchange), "id_token") |> expect.to_be_error()
 }
 
 pub fn parse_token_response_empty_scope_test() {
   let body =
     "{\"access_token\":\"test_token\",\"token_type\":\"Bearer\",\"expires_in\":3600,\"scope\":\"\"}"
   let assert Ok(exchange) = vestibule_apple.parse_token_response(body)
-  exchange.credentials.scopes |> expect.to_equal([])
+  strategy.exchange_credentials(exchange).scopes |> expect.to_equal([])
 }
 
 pub fn parse_token_response_error_test() {
@@ -111,7 +114,7 @@ pub fn authorize_url_invalid_redirect_uri_returns_error_test() {
   let strat = vestibule_apple.strategy(test_apple_cache("invalid_redirect"))
   let conf = config.new("client-id", "secret", "not a uri")
   let _ =
-    strat.authorize_url(conf, ["name", "email"], "state")
+    strategy.build_authorize_url(strat, conf, ["name", "email"], "state")
     |> expect.to_be_error()
   Nil
 }

--- a/packages/vestibule_google/README.md
+++ b/packages/vestibule_google/README.md
@@ -25,6 +25,23 @@ let cfg =
 
 Google userinfo only populates `UserInfo.email` when `email_verified` is true.
 
+## Default scopes
+
+`openid email profile`. Override with `config.with_scopes`.
+
+## Google Cloud Console setup
+
+1. Create or select a project at <https://console.cloud.google.com/>.
+2. **APIs & Services → OAuth consent screen**: configure the consent
+   screen (User Type, app name, support email, scopes
+   `openid`, `email`, `profile`).
+3. **APIs & Services → Credentials → Create credentials → OAuth client ID**.
+4. Application type: *Web application*.
+5. Add your redirect URI exactly, e.g.
+   `http://localhost:8000/auth/google/callback` for development and
+   the HTTPS production URI.
+6. Copy the **Client ID** and **Client secret** into your environment.
+
 ## Refresh tokens
 
 Google only returns a refresh token on the first user consent for a given

--- a/packages/vestibule_google/src/vestibule_google.gleam
+++ b/packages/vestibule_google/src/vestibule_google.gleam
@@ -1,3 +1,9 @@
+//// Google OAuth 2.0 / OIDC strategy.
+////
+//// Uses Google's discovery document to build authorize/token/userinfo
+//// endpoints, requests `openid email profile` by default, and validates
+//// `email_verified` before populating `UserInfo.email`.
+
 import gleam/dict
 import gleam/dynamic/decode
 import gleam/json
@@ -18,12 +24,12 @@ import vestibule/config.{type Config}
 import vestibule/credentials.{type Credentials}
 import vestibule/error.{type AuthError}
 import vestibule/provider_support
-import vestibule/strategy.{type Strategy, type UserResult, Strategy, UserResult}
+import vestibule/strategy.{type Strategy, type UserResult}
 import vestibule/user_info
 
 /// Create a Google authentication strategy.
 pub fn strategy() -> Strategy(e) {
-  Strategy(
+  strategy.new(
     provider: "google",
     default_scopes: ["openid", "profile", "email"],
     authorize_url: do_authorize_url,
@@ -214,7 +220,7 @@ fn do_fetch_user(
   exchange: strategy.ExchangeResult,
 ) -> Result(UserResult, AuthError(e)) {
   use auth_header <- result.try(strategy.authorization_header(
-    exchange.credentials,
+    strategy.exchange_credentials(exchange),
   ))
   use #(uid, info) <- result.try(provider_support.fetch_json_with_auth(
     "https://www.googleapis.com/oauth2/v3/userinfo",
@@ -222,5 +228,5 @@ fn do_fetch_user(
     parse_user_response,
     "Google userinfo",
   ))
-  Ok(UserResult(uid: uid, info: info, extra: dict.new()))
+  Ok(strategy.user_result(uid: uid, info: info, extra: dict.new()))
 }

--- a/packages/vestibule_google/test/vestibule_google_test.gleam
+++ b/packages/vestibule_google/test/vestibule_google_test.gleam
@@ -4,6 +4,7 @@ import startest
 import startest/expect
 import vestibule/config
 import vestibule/credentials.{Credentials}
+import vestibule/strategy
 import vestibule/error
 import vestibule_google
 
@@ -111,7 +112,7 @@ pub fn authorize_url_invalid_redirect_uri_returns_error_test() {
   let strat = vestibule_google.strategy()
   let conf = config.new("client-id", "secret", "not a uri")
   let _ =
-    strat.authorize_url(conf, ["openid"], "state")
+    strategy.build_authorize_url(strat, conf, ["openid"], "state")
     |> expect.to_be_error()
   Nil
 }
@@ -121,6 +122,6 @@ pub fn authorize_url_includes_extra_params_test() {
   let assert Ok(conf) =
     config.new("client-id", "secret", "http://localhost/callback")
     |> config.with_extra_params([#("prompt", "consent")])
-  let assert Ok(url) = strat.authorize_url(conf, ["openid"], "state")
+  let assert Ok(url) = strategy.build_authorize_url(strat, conf, ["openid"], "state")
   { string.contains(url, "prompt=consent") } |> expect.to_be_true()
 }

--- a/packages/vestibule_microsoft/README.md
+++ b/packages/vestibule_microsoft/README.md
@@ -26,6 +26,28 @@ let cfg =
 The strategy uses Microsoft Graph `/me` for profile data and keeps
 `userPrincipalName` as the nickname rather than treating it as a verified email.
 
+## Default scopes
+
+`openid email profile offline_access`. Override with `config.with_scopes`.
+
+## Azure portal setup
+
+1. Sign in to <https://portal.azure.com/> and open **Microsoft Entra ID
+   → App registrations → New registration**.
+2. **Supported account types**: pick one that matches the tenant
+   behavior section below (most apps want
+   *Accounts in any organizational directory and personal Microsoft
+   accounts*).
+3. **Redirect URI**: platform *Web*, value
+   `http://localhost:8000/auth/microsoft/callback` for dev (add the
+   HTTPS production URI as a second entry).
+4. After creation, copy the **Application (client) ID**.
+5. **Certificates & secrets → New client secret** → copy the secret
+   `Value` (not the ID). It is shown once.
+6. **API permissions**: the default `User.Read` (delegated) is enough
+   for the built-in Graph `/me` parsing; click **Grant admin consent**
+   if your tenant requires it.
+
 ## Tenant behavior
 
 The built-in strategy uses Microsoft Entra ID's `/common` tenant:

--- a/packages/vestibule_microsoft/README.md
+++ b/packages/vestibule_microsoft/README.md
@@ -28,7 +28,7 @@ The strategy uses Microsoft Graph `/me` for profile data and keeps
 
 ## Default scopes
 
-`openid email profile offline_access`. Override with `config.with_scopes`.
+`User.Read`. Override with `config.with_scopes`.
 
 ## Azure portal setup
 

--- a/packages/vestibule_microsoft/src/vestibule_microsoft.gleam
+++ b/packages/vestibule_microsoft/src/vestibule_microsoft.gleam
@@ -1,3 +1,10 @@
+//// Microsoft Identity Platform (v2.0) strategy.
+////
+//// Supports common, organizations, consumers, and per-tenant authorities.
+//// Requests `openid email profile offline_access` by default. Tokens are
+//// exchanged against `/oauth2/v2.0/token`; user info comes from Microsoft
+//// Graph `/me`.
+
 import gleam/dict
 import gleam/dynamic/decode
 import gleam/json
@@ -18,12 +25,12 @@ import vestibule/config.{type Config}
 import vestibule/credentials.{type Credentials}
 import vestibule/error.{type AuthError}
 import vestibule/provider_support
-import vestibule/strategy.{type Strategy, type UserResult, Strategy, UserResult}
+import vestibule/strategy.{type Strategy, type UserResult}
 import vestibule/user_info.{type UserInfo}
 
 /// Create a Microsoft authentication strategy using /common tenant.
 pub fn strategy() -> Strategy(e) {
-  Strategy(
+  strategy.new(
     provider: "microsoft",
     default_scopes: ["User.Read"],
     authorize_url: do_authorize_url,
@@ -193,7 +200,7 @@ fn do_refresh_token(
       use body <- result.try(provider_support.check_response_status(response))
       provider_support.parse_oauth_token_response(
         body,
-        provider_support.OptionalScope(" "),
+        provider_support.RequiredScope(separator: " "),
       )
     }
     Error(_) ->
@@ -208,7 +215,7 @@ fn do_fetch_user(
   exchange: strategy.ExchangeResult,
 ) -> Result(UserResult, AuthError(e)) {
   use auth_header <- result.try(strategy.authorization_header(
-    exchange.credentials,
+    strategy.exchange_credentials(exchange),
   ))
   use #(uid, info) <- result.try(provider_support.fetch_json_with_auth(
     "https://graph.microsoft.com/v1.0/me",
@@ -216,5 +223,5 @@ fn do_fetch_user(
     parse_user_response,
     "Microsoft Graph",
   ))
-  Ok(UserResult(uid: uid, info: info, extra: dict.new()))
+  Ok(strategy.user_result(uid: uid, info: info, extra: dict.new()))
 }

--- a/packages/vestibule_microsoft/src/vestibule_microsoft.gleam
+++ b/packages/vestibule_microsoft/src/vestibule_microsoft.gleam
@@ -1,7 +1,7 @@
 //// Microsoft Identity Platform (v2.0) strategy.
 ////
 //// Supports common, organizations, consumers, and per-tenant authorities.
-//// Requests `openid email profile offline_access` by default. Tokens are
+//// Requests `User.Read` by default. Tokens are
 //// exchanged against `/oauth2/v2.0/token`; user info comes from Microsoft
 //// Graph `/me`.
 
@@ -214,9 +214,9 @@ fn do_fetch_user(
   _cfg: Config,
   exchange: strategy.ExchangeResult,
 ) -> Result(UserResult, AuthError(e)) {
-  use auth_header <- result.try(strategy.authorization_header(
-    strategy.exchange_credentials(exchange),
-  ))
+  use auth_header <- result.try(
+    strategy.authorization_header(strategy.exchange_credentials(exchange)),
+  )
   use #(uid, info) <- result.try(provider_support.fetch_json_with_auth(
     "https://graph.microsoft.com/v1.0/me",
     auth_header,

--- a/packages/vestibule_microsoft/test/vestibule_microsoft_test.gleam
+++ b/packages/vestibule_microsoft/test/vestibule_microsoft_test.gleam
@@ -3,6 +3,7 @@ import gleam/string
 import startest
 import startest/expect
 import vestibule/config
+import vestibule/strategy
 import vestibule/credentials.{Credentials}
 import vestibule_microsoft
 
@@ -95,7 +96,7 @@ pub fn authorize_url_invalid_redirect_uri_returns_error_test() {
   let strat = vestibule_microsoft.strategy()
   let conf = config.new("client-id", "secret", "not a uri")
   let _ =
-    strat.authorize_url(conf, ["User.Read"], "state")
+    strategy.build_authorize_url(strat, conf, ["User.Read"], "state")
     |> expect.to_be_error()
   Nil
 }
@@ -105,6 +106,6 @@ pub fn authorize_url_includes_extra_params_test() {
   let assert Ok(conf) =
     config.new("client-id", "secret", "http://localhost/callback")
     |> config.with_extra_params([#("prompt", "select_account")])
-  let assert Ok(url) = strat.authorize_url(conf, ["User.Read"], "state")
+  let assert Ok(url) = strategy.build_authorize_url(strat, conf, ["User.Read"], "state")
   { string.contains(url, "prompt=select_account") } |> expect.to_be_true()
 }

--- a/packages/vestibule_microsoft/test/vestibule_microsoft_test.gleam
+++ b/packages/vestibule_microsoft/test/vestibule_microsoft_test.gleam
@@ -3,8 +3,8 @@ import gleam/string
 import startest
 import startest/expect
 import vestibule/config
-import vestibule/strategy
 import vestibule/credentials.{Credentials}
+import vestibule/strategy
 import vestibule_microsoft
 
 pub fn main() -> Nil {
@@ -106,6 +106,7 @@ pub fn authorize_url_includes_extra_params_test() {
   let assert Ok(conf) =
     config.new("client-id", "secret", "http://localhost/callback")
     |> config.with_extra_params([#("prompt", "select_account")])
-  let assert Ok(url) = strategy.build_authorize_url(strat, conf, ["User.Read"], "state")
+  let assert Ok(url) =
+    strategy.build_authorize_url(strat, conf, ["User.Read"], "state")
   { string.contains(url, "prompt=select_account") } |> expect.to_be_true()
 }

--- a/packages/vestibule_wisp/src/vestibule_wisp.gleam
+++ b/packages/vestibule_wisp/src/vestibule_wisp.gleam
@@ -1,3 +1,11 @@
+//// Wisp middleware that wires a `Registry` of `Strategy` values into HTTP
+//// endpoints.
+////
+//// Provides `request_phase` (start an authorization flow, persist `state`
+//// and `code_verifier`) and `callback_phase` (validate state, exchange
+//// code, fetch user, invoke caller's success handler). Uses a `StateStore`
+//// for single-use storage of in-flight flow state.
+
 import gleam/bit_array
 import gleam/dict
 import gleam/http
@@ -9,8 +17,10 @@ import wisp.{type Request, type Response}
 
 import vestibule
 import vestibule/auth.{type Auth}
+import vestibule/authorization_request
 import vestibule/error
 import vestibule/registry.{type Registry}
+import vestibule/state
 import vestibule_wisp/state_store.{type StateStore}
 
 /// Middleware configuration options.
@@ -72,13 +82,13 @@ pub fn request_phase_with_options(
           case
             state_store.try_store_with_ttl(
               state_store,
-              auth_request.state,
-              auth_request.code_verifier,
+              authorization_request.state(auth_request),
+              authorization_request.code_verifier(auth_request),
               options.session_ttl_seconds,
             )
           {
             Ok(session_id) ->
-              wisp.redirect(auth_request.url)
+              wisp.redirect(authorization_request.url(auth_request))
               |> wisp.set_cookie(
                 req,
                 options.cookie_name,
@@ -245,10 +255,10 @@ pub fn callback_phase_auth_result_with_options(
     |> result.map_error(fn(_) { SessionExpired }),
   )
 
-  use _ <- result.try(case received_state == expected_state {
-    True -> Ok(Nil)
-    False -> Error(AuthFailed(error.StateMismatch))
-  })
+  use _ <- result.try(
+    state.validate(received_state, expected_state)
+    |> result.map_error(AuthFailed),
+  )
 
   use #(expected_state, code_verifier) <- result.try(
     state_store.retrieve(state_store, session_id)

--- a/packages/vestibule_wisp/src/vestibule_wisp/state_store.gleam
+++ b/packages/vestibule_wisp/src/vestibule_wisp/state_store.gleam
@@ -1,3 +1,7 @@
+//// Single-use storage for in-flight OAuth flow state (CSRF `state` and
+//// PKCE `code_verifier`). Entries are deleted on first read to prevent
+//// replay.
+
 import gleam/bit_array
 import gleam/crypto
 import gleam/order

--- a/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
+++ b/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
@@ -5,7 +5,7 @@ import startest/expect
 import vestibule/config
 import vestibule/error
 import vestibule/registry
-import vestibule/strategy.{type Strategy, Strategy}
+import vestibule/strategy.{type Strategy}
 import vestibule_wisp
 import vestibule_wisp/state_store
 import wisp
@@ -192,7 +192,7 @@ pub fn callback_phase_auth_result_missing_state_does_not_consume_session_test() 
 }
 
 fn test_strategy() -> Strategy(e) {
-  Strategy(
+  strategy.new(
     provider: "test",
     default_scopes: [],
     authorize_url: fn(_config, _scopes, _state) { Ok("https://example.com") },

--- a/src/vestibule.gleam
+++ b/src/vestibule.gleam
@@ -11,9 +11,7 @@ import gleam/string
 import gleam/uri
 
 import vestibule/auth.{type Auth, Auth}
-import vestibule/authorization_request.{
-  type AuthorizationRequest, AuthorizationRequest,
-}
+import vestibule/authorization_request.{type AuthorizationRequest}
 import vestibule/config.{type Config}
 import vestibule/credentials.{type Credentials}
 import vestibule/error.{type AuthError}
@@ -35,19 +33,24 @@ import vestibule/strategy.{type Strategy}
 /// timestamp alongside the state when saving it to your session and
 /// check it before calling `handle_callback`.
 pub fn authorize_url(
-  strategy: Strategy(e),
+  strat: Strategy(e),
   cfg: Config,
 ) -> Result(AuthorizationRequest, AuthError(e)) {
   let csrf_state = state.generate()
   let code_verifier = pkce.generate_verifier()
   let code_challenge = pkce.compute_challenge(code_verifier)
   let scopes = case config.scopes(cfg) {
-    [] -> strategy.default_scopes
+    [] -> strategy.default_scopes(strat)
     custom -> custom
   }
-  use base_url <- result.try(strategy.authorize_url(cfg, scopes, csrf_state))
+  use base_url <- result.try(strategy.build_authorize_url(
+    strat,
+    cfg,
+    scopes,
+    csrf_state,
+  ))
   let url = append_pkce_params(base_url, code_challenge)
-  Ok(AuthorizationRequest(
+  Ok(authorization_request.new(
     url: url,
     state: csrf_state,
     code_verifier: code_verifier,
@@ -68,7 +71,7 @@ pub fn authorize_url(
 /// expiration, check the timestamp you stored alongside the state
 /// before calling this function.
 pub fn handle_callback(
-  strategy: Strategy(e),
+  strat: Strategy(e),
   cfg: Config,
   callback_params: Dict(String, String),
   expected_state: String,
@@ -94,21 +97,22 @@ pub fn handle_callback(
 
   // Exchange code for credentials and provider-specific artifacts, passing the PKCE verifier
   use exchange <- result.try(strategy.exchange_code(
+    strat,
     cfg,
     code,
     option.Some(code_verifier),
   ))
 
   // Fetch user info
-  use user <- result.try(strategy.fetch_user(cfg, exchange))
+  use user <- result.try(strategy.fetch_user(strat, cfg, exchange))
 
   // Assemble the Auth result
   Ok(Auth(
-    uid: user.uid,
-    provider: strategy.provider,
-    info: user.info,
-    credentials: exchange.credentials,
-    extra: user.extra,
+    uid: strategy.user_result_uid(user),
+    provider: strategy.provider(strat),
+    info: strategy.user_result_info(user),
+    credentials: strategy.exchange_credentials(exchange),
+    extra: strategy.user_result_extra(user),
   ))
 }
 
@@ -116,11 +120,11 @@ pub fn handle_callback(
 ///
 /// Delegates to the provider strategy so refresh semantics remain provider-owned.
 pub fn refresh_token(
-  strategy: Strategy(e),
+  strat: Strategy(e),
   cfg: Config,
   refresh_tok: String,
 ) -> Result(Credentials, AuthError(e)) {
-  strategy.refresh_token(cfg, refresh_tok)
+  strategy.refresh_token(strat, cfg, refresh_tok)
 }
 
 /// Check callback params for a provider error response.

--- a/src/vestibule/auth.gleam
+++ b/src/vestibule/auth.gleam
@@ -1,3 +1,6 @@
+//// Authentication result types returned to the calling application after a
+//// successful OAuth/OIDC flow.
+
 import gleam/dict.{type Dict}
 import gleam/dynamic.{type Dynamic}
 import vestibule/credentials.{type Credentials}

--- a/src/vestibule/authorization_request.gleam
+++ b/src/vestibule/authorization_request.gleam
@@ -1,15 +1,42 @@
+//// An opaque value carrying everything the middleware needs to start an
+//// authorization flow: the URL to redirect the browser to, the CSRF
+//// `state`, and the PKCE `code_verifier` that must be stored for the
+//// callback.
+
 /// Represents the result of generating an authorization URL.
 ///
 /// Contains all values needed for the OAuth2 authorization phase,
 /// including PKCE parameters that must be stored for the callback phase.
-pub type AuthorizationRequest {
-  AuthorizationRequest(
-    /// The authorization URL to redirect the user to.
-    url: String,
-    /// The CSRF state parameter (must be stored for validation).
-    /// Store a timestamp alongside it if you need time-based expiration.
-    state: String,
-    /// The PKCE code verifier (must be stored for token exchange).
-    code_verifier: String,
-  )
+///
+/// Opaque so that new artifacts (e.g., an OIDC `nonce`) can be added
+/// without breaking consumers. Construct with `new` and read fields via
+/// the `url`, `state`, and `code_verifier` accessors.
+pub opaque type AuthorizationRequest {
+  AuthorizationRequest(url: String, state: String, code_verifier: String)
+}
+
+/// Build an `AuthorizationRequest`.
+pub fn new(
+  url url: String,
+  state state: String,
+  code_verifier code_verifier: String,
+) -> AuthorizationRequest {
+  AuthorizationRequest(url: url, state: state, code_verifier: code_verifier)
+}
+
+/// The authorization URL to redirect the user to.
+pub fn url(req: AuthorizationRequest) -> String {
+  req.url
+}
+
+/// The CSRF state parameter (must be stored for validation).
+///
+/// Store a timestamp alongside it if you need time-based expiration.
+pub fn state(req: AuthorizationRequest) -> String {
+  req.state
+}
+
+/// The PKCE code verifier (must be stored for token exchange).
+pub fn code_verifier(req: AuthorizationRequest) -> String {
+  req.code_verifier
 }

--- a/src/vestibule/config.gleam
+++ b/src/vestibule/config.gleam
@@ -1,3 +1,7 @@
+//// OAuth provider configuration. Each `ProviderConfig` carries the
+//// `client_id`, `client_secret`, `redirect_uri`, and optional per-strategy
+//// overrides used to build authorization requests and exchange codes.
+
 import gleam/dict.{type Dict}
 import gleam/list
 import vestibule/error.{type AuthError}

--- a/src/vestibule/credentials.gleam
+++ b/src/vestibule/credentials.gleam
@@ -1,3 +1,10 @@
+//// Bearer credentials returned by a provider after a successful token
+//// exchange or refresh.
+////
+//// > **Security**: `Credentials` values contain access/refresh/id tokens.
+//// > Treat them like passwords — never log them, never include them in
+//// > error reports, and store them encrypted at rest.
+
 import gleam/option.{type Option}
 
 /// OAuth credentials from the provider.

--- a/src/vestibule/oidc.gleam
+++ b/src/vestibule/oidc.gleam
@@ -31,7 +31,7 @@ import vestibule/config
 import vestibule/credentials.{type Credentials}
 import vestibule/error.{type AuthError}
 import vestibule/provider_support
-import vestibule/strategy.{type Strategy, type UserResult, Strategy, UserResult}
+import vestibule/strategy.{type Strategy, type UserResult}
 import vestibule/user_info
 
 /// Configuration discovered from an OpenID Connect provider's
@@ -245,7 +245,7 @@ pub fn strategy_from_config(
   provider_name: String,
 ) -> Strategy(e) {
   let scopes = filter_default_scopes(oidc_config.scopes_supported)
-  Strategy(
+  strategy.new(
     provider: provider_name,
     default_scopes: scopes,
     authorize_url: build_authorize_url_fn(oidc_config.authorization_endpoint),
@@ -472,16 +472,16 @@ fn build_fetch_user_fn(
     UserResult,
     AuthError(e),
   ) {
-    use auth_header <- result.try(strategy.authorization_header(
-      exchange.credentials,
-    ))
+    use auth_header <- result.try(
+      strategy.authorization_header(strategy.exchange_credentials(exchange)),
+    )
     use #(uid, info) <- result.try(provider_support.fetch_json_with_auth(
       userinfo_endpoint,
       auth_header,
       parse_userinfo_response,
       "OIDC userinfo",
     ))
-    Ok(UserResult(uid: uid, info: info, extra: dict.new()))
+    Ok(strategy.user_result(uid: uid, info: info, extra: dict.new()))
   }
 }
 

--- a/src/vestibule/registry.gleam
+++ b/src/vestibule/registry.gleam
@@ -1,3 +1,7 @@
+//// In-memory registry that maps provider names ("google", "apple", ...)
+//// to `Strategy` values. Used by the middleware to dispatch incoming
+//// authorize/callback requests to the right provider.
+
 import gleam/dict.{type Dict}
 import vestibule/config.{type Config}
 import vestibule/strategy.{type Strategy}
@@ -21,7 +25,7 @@ pub fn register(
   config: Config,
 ) -> Registry(e) {
   Registry(
-    providers: dict.insert(registry.providers, strategy.provider, #(
+    providers: dict.insert(registry.providers, strategy.provider(strategy), #(
       strategy,
       config,
     )),

--- a/src/vestibule/state.gleam
+++ b/src/vestibule/state.gleam
@@ -1,3 +1,7 @@
+//// CSRF state token generation and constant-time validation. A fresh
+//// 256-bit base64url token is minted for every authorization request and
+//// must be echoed back unchanged on the callback.
+
 import gleam/bit_array
 import gleam/crypto
 import gleam/string

--- a/src/vestibule/strategy.gleam
+++ b/src/vestibule/strategy.gleam
@@ -1,3 +1,11 @@
+//// Provider-strategy interface. A `Strategy(e)` is an opaque record
+//// bundling the four functions every OAuth/OIDC provider must implement:
+//// build authorize URL, exchange code, refresh token, and fetch user.
+////
+//// Provider packages (`vestibule_google`, `vestibule_apple`, ...) build
+//// these with `strategy.new`; the core library invokes them through the
+//// exposed accessors.
+
 import gleam/dict.{type Dict}
 import gleam/dynamic.{type Dynamic}
 import gleam/http/request
@@ -11,8 +19,36 @@ import vestibule/error.{type AuthError}
 import vestibule/user_info.{type UserInfo}
 
 /// Normalized user details returned by a strategy.
-pub type UserResult {
+///
+/// Opaque so that new fields can be added without breaking strategy
+/// implementations. Construct with `user_result` and read with the
+/// `uid` / `info` / `extra` accessors.
+pub opaque type UserResult {
   UserResult(uid: String, info: UserInfo, extra: Dict(String, Dynamic))
+}
+
+/// Build a `UserResult`.
+pub fn user_result(
+  uid uid: String,
+  info info: UserInfo,
+  extra extra: Dict(String, Dynamic),
+) -> UserResult {
+  UserResult(uid: uid, info: info, extra: extra)
+}
+
+/// Return the provider's unique user id.
+pub fn user_result_uid(user: UserResult) -> String {
+  user.uid
+}
+
+/// Return the normalized user info.
+pub fn user_result_info(user: UserResult) -> UserInfo {
+  user.info
+}
+
+/// Return provider-specific extra fields associated with the user.
+pub fn user_result_extra(user: UserResult) -> Dict(String, Dynamic) {
+  user.extra
 }
 
 /// The result of exchanging an authorization code.
@@ -20,7 +56,9 @@ pub type UserResult {
 /// `credentials` contains the standard OAuth credentials. `artifacts` contains
 /// provider-specific token response data that may be needed while resolving the
 /// user, such as an OpenID Connect `id_token`.
-pub type ExchangeResult {
+///
+/// Opaque to keep provider-specific artifacts evolution-safe.
+pub opaque type ExchangeResult {
   ExchangeResult(credentials: Credentials, artifacts: Dict(String, Dynamic))
 }
 
@@ -37,30 +75,120 @@ pub fn exchange_result_with_artifacts(
   ExchangeResult(credentials: credentials, artifacts: artifacts)
 }
 
-/// A strategy is a record containing the functions needed
-/// to authenticate with a specific provider.
+/// Return the OAuth credentials produced by the exchange.
+pub fn exchange_credentials(exchange: ExchangeResult) -> Credentials {
+  exchange.credentials
+}
+
+/// Return provider-specific artifacts produced by the exchange
+/// (e.g., an OpenID Connect `id_token`).
+pub fn exchange_artifacts(exchange: ExchangeResult) -> Dict(String, Dynamic) {
+  exchange.artifacts
+}
+
+/// A strategy is the bundle of provider-specific functions needed to
+/// authenticate with a single OAuth/OIDC provider.
 ///
-/// The type parameter `e` corresponds to the custom error type
-/// in `AuthError(e)`. Built-in strategies are polymorphic in `e`.
-pub type Strategy(e) {
+/// The type parameter `e` corresponds to the custom error type in
+/// `AuthError(e)`. Built-in strategies are polymorphic in `e`.
+///
+/// Opaque so that vestibule can add fields (or swap the internal
+/// representation, e.g., to an injectable HTTP client) without breaking
+/// provider packages. Construct with `new` and invoke with the
+/// `build_authorize_url`, `exchange_code`, `refresh_token`, and
+/// `fetch_user` helpers.
+pub opaque type Strategy(e) {
   Strategy(
-    /// Human-readable provider name (e.g., "github", "google").
     provider: String,
-    /// Default scopes for this provider.
     default_scopes: List(String),
-    /// Build the authorization URL to redirect the user to.
-    /// Parameters: config, scopes, state.
     authorize_url: fn(Config, List(String), String) ->
       Result(String, AuthError(e)),
-    /// Exchange an authorization code for credentials and provider-specific artifacts.
-    /// The third parameter is an optional PKCE code verifier.
     exchange_code: fn(Config, String, Option(String)) ->
       Result(ExchangeResult, AuthError(e)),
-    /// Refresh credentials using a provider-specific refresh token request.
     refresh_token: fn(Config, String) -> Result(Credentials, AuthError(e)),
-    /// Fetch user info using the obtained exchange result.
     fetch_user: fn(Config, ExchangeResult) -> Result(UserResult, AuthError(e)),
   )
+}
+
+/// Build a `Strategy`.
+///
+/// `authorize_url` builds the provider-specific authorization URL.
+/// `exchange_code` exchanges an authorization code for credentials and
+/// optional provider-specific artifacts; the third parameter is the PKCE
+/// `code_verifier` if one was generated. `refresh_token` swaps a refresh
+/// token for fresh credentials. `fetch_user` resolves the authenticated
+/// user from the exchange result.
+pub fn new(
+  provider provider: String,
+  default_scopes default_scopes: List(String),
+  authorize_url authorize_url: fn(Config, List(String), String) ->
+    Result(String, AuthError(e)),
+  exchange_code exchange_code: fn(Config, String, Option(String)) ->
+    Result(ExchangeResult, AuthError(e)),
+  refresh_token refresh_token: fn(Config, String) ->
+    Result(Credentials, AuthError(e)),
+  fetch_user fetch_user: fn(Config, ExchangeResult) ->
+    Result(UserResult, AuthError(e)),
+) -> Strategy(e) {
+  Strategy(
+    provider: provider,
+    default_scopes: default_scopes,
+    authorize_url: authorize_url,
+    exchange_code: exchange_code,
+    refresh_token: refresh_token,
+    fetch_user: fetch_user,
+  )
+}
+
+/// Return the human-readable provider name (e.g., `"github"`, `"google"`).
+pub fn provider(strat: Strategy(e)) -> String {
+  strat.provider
+}
+
+/// Return the strategy's default scopes, used when the caller's
+/// `Config` does not specify any.
+pub fn default_scopes(strat: Strategy(e)) -> List(String) {
+  strat.default_scopes
+}
+
+/// Build the provider's authorization URL.
+pub fn build_authorize_url(
+  strat: Strategy(e),
+  cfg: Config,
+  scopes: List(String),
+  state: String,
+) -> Result(String, AuthError(e)) {
+  strat.authorize_url(cfg, scopes, state)
+}
+
+/// Exchange an authorization code for credentials and any provider-specific
+/// artifacts. Pass the PKCE `code_verifier` if one was generated for the
+/// authorization request.
+pub fn exchange_code(
+  strat: Strategy(e),
+  cfg: Config,
+  code: String,
+  code_verifier: Option(String),
+) -> Result(ExchangeResult, AuthError(e)) {
+  strat.exchange_code(cfg, code, code_verifier)
+}
+
+/// Refresh credentials using a refresh token.
+pub fn refresh_token(
+  strat: Strategy(e),
+  cfg: Config,
+  refresh_tok: String,
+) -> Result(Credentials, AuthError(e)) {
+  strat.refresh_token(cfg, refresh_tok)
+}
+
+/// Fetch user info using the obtained exchange result.
+pub fn fetch_user(
+  strat: Strategy(e),
+  cfg: Config,
+  exchange: ExchangeResult,
+) -> Result(UserResult, AuthError(e)) {
+  strat.fetch_user(cfg, exchange)
 }
 
 /// Build the Authorization header value from credentials.

--- a/src/vestibule/strategy/github.gleam
+++ b/src/vestibule/strategy/github.gleam
@@ -20,12 +20,12 @@ import vestibule/config.{type Config}
 import vestibule/credentials.{type Credentials}
 import vestibule/error.{type AuthError}
 import vestibule/provider_support
-import vestibule/strategy.{type Strategy, type UserResult, Strategy, UserResult}
+import vestibule/strategy.{type Strategy, type UserResult}
 import vestibule/user_info.{type UserInfo}
 
 /// Create a GitHub authentication strategy.
 pub fn strategy() -> Strategy(e) {
-  Strategy(
+  strategy.new(
     provider: "github",
     default_scopes: ["user:email"],
     authorize_url: do_authorize_url,
@@ -242,7 +242,7 @@ fn do_fetch_user(
   _cfg: Config,
   exchange: strategy.ExchangeResult,
 ) -> Result(UserResult, AuthError(e)) {
-  let creds = exchange.credentials
+  let creds = strategy.exchange_credentials(exchange)
   // Validate token type
   use auth_header <- result.try(strategy.authorization_header(creds))
 
@@ -291,5 +291,5 @@ fn do_fetch_user(
     None -> info
   }
 
-  Ok(UserResult(uid: uid, info: final_info, extra: dict.new()))
+  Ok(strategy.user_result(uid: uid, info: final_info, extra: dict.new()))
 }

--- a/src/vestibule/user_info.gleam
+++ b/src/vestibule/user_info.gleam
@@ -1,3 +1,6 @@
+//// Normalized user profile returned by a provider's userinfo endpoint or
+//// extracted from an ID token. Provider-specific fields land in `extra`.
+
 import gleam/dict.{type Dict}
 import gleam/option.{type Option}
 

--- a/test/vestibule/oidc_test.gleam
+++ b/test/vestibule/oidc_test.gleam
@@ -6,6 +6,7 @@ import vestibule/config
 import vestibule/credentials.{Credentials}
 import vestibule/error
 import vestibule/oidc
+import vestibule/strategy
 
 // --- OidcConfig construction ---
 
@@ -313,7 +314,7 @@ pub fn filter_default_scopes_empty_test() {
 pub fn strategy_from_config_sets_provider_name_test() {
   let oidc_config = example_config()
   let strat = oidc.strategy_from_config(oidc_config, "my-oidc-provider")
-  strat.provider |> expect.to_equal("my-oidc-provider")
+  strategy.provider(strat) |> expect.to_equal("my-oidc-provider")
 }
 
 pub fn strategy_from_config_sets_default_scopes_test() {
@@ -326,7 +327,8 @@ pub fn strategy_from_config_sets_default_scopes_test() {
       scopes_supported: ["openid", "profile", "email", "address"],
     )
   let strat = oidc.strategy_from_config(oidc_config, "example")
-  strat.default_scopes |> expect.to_equal(["openid", "profile", "email"])
+  strategy.default_scopes(strat)
+  |> expect.to_equal(["openid", "profile", "email"])
 }
 
 pub fn strategy_from_config_filters_scopes_test() {
@@ -339,7 +341,7 @@ pub fn strategy_from_config_filters_scopes_test() {
       scopes_supported: ["openid", "custom"],
     )
   let strat = oidc.strategy_from_config(oidc_config, "example")
-  strat.default_scopes |> expect.to_equal(["openid"])
+  strategy.default_scopes(strat) |> expect.to_equal(["openid"])
 }
 
 pub fn strategy_from_config_defaults_to_openid_without_scope_metadata_test() {
@@ -352,7 +354,7 @@ pub fn strategy_from_config_defaults_to_openid_without_scope_metadata_test() {
       scopes_supported: [],
     )
   let strat = oidc.strategy_from_config(oidc_config, "example")
-  strat.default_scopes |> expect.to_equal(["openid"])
+  strategy.default_scopes(strat) |> expect.to_equal(["openid"])
 }
 
 pub fn strategy_from_config_defaults_to_openid_when_no_desired_scopes_supported_test() {
@@ -365,7 +367,7 @@ pub fn strategy_from_config_defaults_to_openid_when_no_desired_scopes_supported_
       scopes_supported: ["custom_scope"],
     )
   let strat = oidc.strategy_from_config(oidc_config, "example")
-  strat.default_scopes |> expect.to_equal(["openid"])
+  strategy.default_scopes(strat) |> expect.to_equal(["openid"])
 }
 
 pub fn strategy_from_config_authorize_url_test() {
@@ -373,7 +375,13 @@ pub fn strategy_from_config_authorize_url_test() {
   let strat = oidc.strategy_from_config(oidc_config, "example")
   let conf =
     config.new("my-client-id", "my-secret", "http://localhost/callback")
-  let result = strat.authorize_url(conf, ["openid", "profile"], "test-state")
+  let result =
+    strategy.build_authorize_url(
+      strat,
+      conf,
+      ["openid", "profile"],
+      "test-state",
+    )
   let assert Ok(url) = result
   // Verify all expected query parameters are in the URL
   { string.contains(url, "https://accounts.example.com/authorize") }
@@ -398,7 +406,8 @@ pub fn strategy_from_config_authorize_url_with_extra_params_test() {
   let assert Ok(conf) =
     config.new("client-id", "secret", "http://localhost/cb")
     |> config.with_extra_params([#("prompt", "consent")])
-  let assert Ok(url) = strat.authorize_url(conf, ["openid"], "state-123")
+  let assert Ok(url) =
+    strategy.build_authorize_url(strat, conf, ["openid"], "state-123")
   { string.contains(url, "prompt=consent") } |> expect.to_be_true()
 }
 
@@ -414,7 +423,7 @@ pub fn strategy_from_config_invalid_redirect_uri_returns_error_test() {
   let strat = oidc.strategy_from_config(oidc_config, "example")
   let conf = config.new("client-id", "secret", "not a uri")
   let _ =
-    strat.authorize_url(conf, ["openid"], "state-123")
+    strategy.build_authorize_url(strat, conf, ["openid"], "state-123")
     |> expect.to_be_error()
   Nil
 }

--- a/test/vestibule/registry_test.gleam
+++ b/test/vestibule/registry_test.gleam
@@ -3,10 +3,10 @@ import startest/expect
 import vestibule/config
 import vestibule/error
 import vestibule/registry
-import vestibule/strategy.{type Strategy, Strategy}
+import vestibule/strategy.{type Strategy}
 
 fn test_strategy(name: String) -> Strategy(e) {
-  Strategy(
+  strategy.new(
     provider: name,
     default_scopes: [],
     authorize_url: fn(_config, _scopes, _state) { Ok("https://example.com") },
@@ -39,7 +39,7 @@ pub fn register_and_get_provider_test() {
     registry.new()
     |> registry.register(strategy, cfg)
   let assert Ok(#(s, _c)) = registry.get(reg, "github")
-  s.provider |> expect.to_equal("github")
+  strategy.provider(s) |> expect.to_equal("github")
 }
 
 pub fn get_unknown_provider_returns_error_test() {

--- a/test/vestibule/security_test.gleam
+++ b/test/vestibule/security_test.gleam
@@ -8,7 +8,7 @@ import gleam/option.{None, Some}
 import gleam/string
 import startest/expect
 import vestibule
-import vestibule/authorization_request.{AuthorizationRequest}
+import vestibule/authorization_request
 import vestibule/config
 import vestibule/credentials.{Credentials}
 import vestibule/error
@@ -16,7 +16,7 @@ import vestibule/oidc
 import vestibule/pkce
 import vestibule/provider_support
 import vestibule/state
-import vestibule/strategy.{type Strategy, ExchangeResult, Strategy, UserResult}
+import vestibule/strategy.{type Strategy}
 import vestibule/user_info.{UserInfo}
 
 // ---------------------------------------------------------------------------
@@ -24,7 +24,7 @@ import vestibule/user_info.{UserInfo}
 // ---------------------------------------------------------------------------
 
 fn test_strategy() -> Strategy(e) {
-  Strategy(
+  strategy.new(
     provider: "test",
     default_scopes: ["scope"],
     authorize_url: fn(_config, scopes, st) {
@@ -38,16 +38,17 @@ fn test_strategy() -> Strategy(e) {
     exchange_code: fn(_config, code, _verifier) {
       case code {
         "valid_code" ->
-          Ok(ExchangeResult(
-            credentials: Credentials(
-              token: "tok",
-              refresh_token: None,
-              token_type: "bearer",
-              expires_in: None,
-              scopes: [],
+          Ok(
+            strategy.exchange_result(
+              Credentials(
+                token: "tok",
+                refresh_token: None,
+                token_type: "bearer",
+                expires_in: None,
+                scopes: [],
+              ),
             ),
-            artifacts: dict.new(),
-          ))
+          )
         _ -> Error(error.CodeExchangeFailed(reason: "bad code"))
       }
     },
@@ -55,7 +56,7 @@ fn test_strategy() -> Strategy(e) {
       Error(error.ConfigError(reason: "refresh not implemented"))
     },
     fetch_user: fn(_config, _exchange) {
-      Ok(UserResult(
+      Ok(strategy.user_result(
         uid: "uid",
         info: UserInfo(
           name: None,
@@ -188,8 +189,8 @@ pub fn pkce_different_verifiers_produce_different_challenges_test() {
 pub fn authorize_url_always_includes_pkce_test() {
   let strat = test_strategy()
   let conf = config.new("id", "secret", "https://localhost/cb")
-  let assert Ok(AuthorizationRequest(url:, ..)) =
-    vestibule.authorize_url(strat, conf)
+  let assert Ok(auth_req) = vestibule.authorize_url(strat, conf)
+  let url = authorization_request.url(auth_req)
   { string.contains(url, "code_challenge=") } |> expect.to_be_true()
   { string.contains(url, "code_challenge_method=S256") } |> expect.to_be_true()
 }
@@ -200,8 +201,13 @@ pub fn authorize_url_produces_fresh_state_and_verifier_test() {
   let conf = config.new("id", "secret", "https://localhost/cb")
   let assert Ok(req1) = vestibule.authorize_url(strat, conf)
   let assert Ok(req2) = vestibule.authorize_url(strat, conf)
-  { req1.state != req2.state } |> expect.to_be_true()
-  { req1.code_verifier != req2.code_verifier } |> expect.to_be_true()
+  { authorization_request.state(req1) != authorization_request.state(req2) }
+  |> expect.to_be_true()
+  {
+    authorization_request.code_verifier(req1)
+    != authorization_request.code_verifier(req2)
+  }
+  |> expect.to_be_true()
 }
 
 // ===========================================================================

--- a/test/vestibule/strategy/github_test.gleam
+++ b/test/vestibule/strategy/github_test.gleam
@@ -4,6 +4,7 @@ import gleam/string
 import startest/expect
 import vestibule/config
 import vestibule/credentials.{Credentials}
+import vestibule/strategy
 import vestibule/strategy/github
 
 pub fn parse_token_response_success_test() {
@@ -92,7 +93,7 @@ pub fn authorize_url_invalid_redirect_uri_returns_error_test() {
   let strat = github.strategy()
   let conf = config.new("client-id", "secret", "not a uri")
   let _ =
-    strat.authorize_url(conf, ["user:email"], "state")
+    strategy.build_authorize_url(strat, conf, ["user:email"], "state")
     |> expect.to_be_error()
   Nil
 }
@@ -102,6 +103,7 @@ pub fn authorize_url_includes_extra_params_test() {
   let assert Ok(conf) =
     config.new("client-id", "secret", "http://localhost/callback")
     |> config.with_extra_params([#("allow_signup", "false")])
-  let assert Ok(url) = strat.authorize_url(conf, ["user:email"], "state")
+  let assert Ok(url) =
+    strategy.build_authorize_url(strat, conf, ["user:email"], "state")
   { string.contains(url, "allow_signup=false") } |> expect.to_be_true()
 }

--- a/test/vestibule_test.gleam
+++ b/test/vestibule_test.gleam
@@ -6,11 +6,11 @@ import gleam/string
 import startest
 import startest/expect
 import vestibule
-import vestibule/authorization_request.{AuthorizationRequest}
+import vestibule/authorization_request
 import vestibule/config
 import vestibule/credentials.{Credentials}
 import vestibule/error
-import vestibule/strategy.{type Strategy, ExchangeResult, Strategy, UserResult}
+import vestibule/strategy.{type Strategy}
 import vestibule/user_info.{UserInfo}
 
 pub fn main() -> Nil {
@@ -19,7 +19,7 @@ pub fn main() -> Nil {
 
 // A fake strategy for testing the orchestrator
 fn test_strategy() -> Strategy(e) {
-  Strategy(
+  strategy.new(
     provider: "test",
     default_scopes: ["default_scope"],
     authorize_url: fn(_config, scopes, state) {
@@ -33,16 +33,17 @@ fn test_strategy() -> Strategy(e) {
     exchange_code: fn(_config, code, _code_verifier) {
       case code {
         "valid_code" ->
-          Ok(ExchangeResult(
-            credentials: Credentials(
-              token: "test_token",
-              refresh_token: None,
-              token_type: "bearer",
-              expires_in: None,
-              scopes: ["default_scope"],
+          Ok(
+            strategy.exchange_result(
+              Credentials(
+                token: "test_token",
+                refresh_token: None,
+                token_type: "bearer",
+                expires_in: None,
+                scopes: ["default_scope"],
+              ),
             ),
-            artifacts: dict.new(),
-          ))
+          )
         _ -> Error(error.CodeExchangeFailed(reason: "bad code"))
       }
     },
@@ -58,8 +59,9 @@ fn test_strategy() -> Strategy(e) {
       )
     },
     fetch_user: fn(_cfg, exchange) {
-      exchange.credentials.token |> expect.to_equal("test_token")
-      Ok(UserResult(
+      strategy.exchange_credentials(exchange).token
+      |> expect.to_equal("test_token")
+      Ok(strategy.user_result(
         uid: "user123",
         info: UserInfo(
           name: Some("Test User"),
@@ -78,22 +80,22 @@ fn test_strategy() -> Strategy(e) {
 }
 
 fn artifact_strategy() -> Strategy(e) {
-  Strategy(
+  strategy.new(
     provider: "artifact",
     default_scopes: [],
     authorize_url: fn(_config, _scopes, state) {
       Ok("https://test.com/auth?state=" <> state)
     },
     exchange_code: fn(_config, _code, _code_verifier) {
-      Ok(ExchangeResult(
-        credentials: Credentials(
+      Ok(strategy.exchange_result_with_artifacts(
+        Credentials(
           token: "artifact_token",
           refresh_token: None,
           token_type: "bearer",
           expires_in: None,
           scopes: [],
         ),
-        artifacts: dict.from_list([
+        dict.from_list([
           #("exchange_marker", dynamic.string("from-exchange")),
         ]),
       ))
@@ -102,9 +104,10 @@ fn artifact_strategy() -> Strategy(e) {
       Error(error.ConfigError(reason: "refresh not implemented"))
     },
     fetch_user: fn(_cfg, exchange) {
-      let assert Ok(marker) = dict.get(exchange.artifacts, "exchange_marker")
+      let assert Ok(marker) =
+        dict.get(strategy.exchange_artifacts(exchange), "exchange_marker")
       let assert Ok(decoded) = decode.run(marker, decode.string)
-      Ok(UserResult(
+      Ok(strategy.user_result(
         uid: decoded,
         info: UserInfo(
           name: None,
@@ -121,24 +124,41 @@ fn artifact_strategy() -> Strategy(e) {
 }
 
 fn fragment_strategy() -> Strategy(e) {
-  Strategy(..test_strategy(), authorize_url: fn(_config, _scopes, state) {
-    Ok(
-      "https://test.com/auth?state=" <> state <> "&existing=1#provider-fragment",
-    )
-  })
+  strategy.new(
+    provider: strategy.provider(test_strategy()),
+    default_scopes: strategy.default_scopes(test_strategy()),
+    authorize_url: fn(_config, _scopes, state) {
+      Ok(
+        "https://test.com/auth?state="
+        <> state
+        <> "&existing=1#provider-fragment",
+      )
+    },
+    exchange_code: fn(cfg, code, verifier) {
+      strategy.exchange_code(test_strategy(), cfg, code, verifier)
+    },
+    refresh_token: fn(cfg, tok) {
+      strategy.refresh_token(test_strategy(), cfg, tok)
+    },
+    fetch_user: fn(cfg, exchange) {
+      strategy.fetch_user(test_strategy(), cfg, exchange)
+    },
+  )
 }
 
 pub fn authorize_url_returns_authorization_request_test() {
   let strat = test_strategy()
   let conf = config.new("id", "secret", "http://localhost/cb")
-  let result = vestibule.authorize_url(strat, conf)
-  let assert Ok(AuthorizationRequest(url:, state:, code_verifier:)) = result
+  let assert Ok(req) = vestibule.authorize_url(strat, conf)
+  let url = authorization_request.url(req)
+  let state = authorization_request.state(req)
+  let verifier = authorization_request.code_verifier(req)
   // URL should contain the state
   { string.contains(url, state) } |> expect.to_be_true()
   // State should be non-empty
   { string.length(state) >= 43 } |> expect.to_be_true()
   // Code verifier should be non-empty
-  { string.length(code_verifier) >= 43 } |> expect.to_be_true()
+  { string.length(verifier) >= 43 } |> expect.to_be_true()
   // URL should contain PKCE params
   { string.contains(url, "code_challenge=") } |> expect.to_be_true()
   { string.contains(url, "code_challenge_method=S256") } |> expect.to_be_true()
@@ -146,8 +166,8 @@ pub fn authorize_url_returns_authorization_request_test() {
 
 pub fn authorize_url_appends_pkce_before_url_fragment_test() {
   let conf = config.new("id", "secret", "http://localhost/cb")
-  let assert Ok(AuthorizationRequest(url:, ..)) =
-    vestibule.authorize_url(fragment_strategy(), conf)
+  let assert Ok(req) = vestibule.authorize_url(fragment_strategy(), conf)
+  let url = authorization_request.url(req)
 
   { string.contains(url, "&existing=1&code_challenge=") }
   |> expect.to_be_true()
@@ -160,8 +180,8 @@ pub fn authorize_url_uses_config_scopes_when_present_test() {
   let conf =
     config.new("id", "secret", "http://localhost/cb")
     |> config.with_scopes(["custom_scope"])
-  let assert Ok(AuthorizationRequest(url:, ..)) =
-    vestibule.authorize_url(strat, conf)
+  let assert Ok(req) = vestibule.authorize_url(strat, conf)
+  let url = authorization_request.url(req)
   { string.contains(url, "custom_scope") } |> expect.to_be_true()
   { string.contains(url, "default_scope") } |> expect.to_be_false()
 }
@@ -169,8 +189,8 @@ pub fn authorize_url_uses_config_scopes_when_present_test() {
 pub fn authorize_url_uses_default_scopes_when_config_empty_test() {
   let strat = test_strategy()
   let conf = config.new("id", "secret", "http://localhost/cb")
-  let assert Ok(AuthorizationRequest(url:, ..)) =
-    vestibule.authorize_url(strat, conf)
+  let assert Ok(req) = vestibule.authorize_url(strat, conf)
+  let url = authorization_request.url(req)
   { string.contains(url, "default_scope") } |> expect.to_be_true()
 }
 

--- a/test/vestibule_test.gleam
+++ b/test/vestibule_test.gleam
@@ -124,9 +124,10 @@ fn artifact_strategy() -> Strategy(e) {
 }
 
 fn fragment_strategy() -> Strategy(e) {
+  let base = test_strategy()
   strategy.new(
-    provider: strategy.provider(test_strategy()),
-    default_scopes: strategy.default_scopes(test_strategy()),
+    provider: strategy.provider(base),
+    default_scopes: strategy.default_scopes(base),
     authorize_url: fn(_config, _scopes, state) {
       Ok(
         "https://test.com/auth?state="
@@ -135,14 +136,10 @@ fn fragment_strategy() -> Strategy(e) {
       )
     },
     exchange_code: fn(cfg, code, verifier) {
-      strategy.exchange_code(test_strategy(), cfg, code, verifier)
+      strategy.exchange_code(base, cfg, code, verifier)
     },
-    refresh_token: fn(cfg, tok) {
-      strategy.refresh_token(test_strategy(), cfg, tok)
-    },
-    fetch_user: fn(cfg, exchange) {
-      strategy.fetch_user(test_strategy(), cfg, exchange)
-    },
+    refresh_token: fn(cfg, tok) { strategy.refresh_token(base, cfg, tok) },
+    fetch_user: fn(cfg, exchange) { strategy.fetch_user(base, cfg, exchange) },
   )
 }
 


### PR DESCRIPTION
## Summary

Result of a comprehensive multi-axis review of the codebase. Fixes two
security bugs, makes the core public types opaque so the API surface
can evolve, and closes documentation gaps surfaced by the review.

## Bug fixes

- **vestibule_wisp**: state comparison in `callback_phase` now uses
  `state.validate` (constant-time, via `crypto.secure_compare`)
  instead of `==`. Closes a timing side-channel on CSRF token
  validation.
- **vestibule_microsoft**: refresh-token responses now use
  `RequiredScope(" ")` to match exchange-code behavior. Previously
  `OptionalScope` would silently return `[]` if Microsoft omitted
  `scope` on refresh, while the exchange path would fail.

## Opaque public types (breaking)

Locks down the public API so internal layout can change without
breaking downstream code. Affected types and how to migrate:

| Type | Construct via | Read via |
|------|---------------|----------|
| `Strategy(e)` | `strategy.new(...)` | `strategy.provider`, `default_scopes`, `build_authorize_url`, `exchange_code`, `refresh_token`, `fetch_user` |
| `UserResult` | `strategy.user_result(...)` | `strategy.user_result_uid`, `_info`, `_extra` |
| `ExchangeResult` | `strategy.exchange_result` / `_with_artifacts` | `strategy.exchange_credentials`, `exchange_artifacts` |
| `AuthorizationRequest` | `authorization_request.new(...)` | `authorization_request.url`, `state`, `code_verifier` |
| `AppleCache` | `vestibule_apple.init` / `try_init` / `try_init_named` | - |
| `JwksCache` | internal | - |

Provider packages, the wisp middleware, the example app, and all tests
were migrated to the new constructors and accessors.

## Documentation sweep

- Added a **Security** section to the root README covering PKCE,
  CSRF state, HTTPS, JWT signature verification, the OIDC `nonce` gap
  ([#44](https://github.com/tylerbutler/vestibule/issues/44)), and
  caller responsibilities (token redaction, cookie rotation, state
  persistence).
- Fixed the non-exhaustive router snippet in the root README
  (`_, _ -> wisp.not_found()` arm).
- Per-package READMEs: documented default scopes and provider-portal
  setup steps (Google Cloud Console, Azure App Registration, Apple
  Developer portal). Apple README links to
  [#43](https://github.com/tylerbutler/vestibule/issues/43) for the
  outstanding client-secret JWT signing helper.
- Corrected Microsoft docs to match the actual `User.Read` default
  scope.
- Converted module-level prose from `///` to `////` in
  `vestibule_apple`, `jwt`, `jwks`.
- Added `////` module-doc headers to 12 modules that lacked them
  (`auth`, `config`, `credentials`, `registry`, `state`, `strategy`,
  `user_info`, `authorization_request`, `vestibule_google`,
  `vestibule_microsoft`, `vestibule_wisp`, `state_store`).
- Removed the empty `packages/vestibule_indieauth/` placeholder.

## Follow-ups

- [#43](https://github.com/tylerbutler/vestibule/issues/43) — Apple
  ES256 `client_secret` JWT signing helper.
- [#44](https://github.com/tylerbutler/vestibule/issues/44) — OIDC
  `nonce` generation and validation.

## Verification

- `just ci`
- `gleam test`
- `just test-pkg vestibule_microsoft`
