### PR TITLE
fix(security)!: harden token handling

### DIFF
--- a/.claude/agents/oauth-security-reviewer.md
+++ b/.claude/agents/oauth-security-reviewer.md
@@ -1,0 +1,114 @@
+---
+name: oauth-security-reviewer
+description: Adversarial security review of OAuth2/OIDC code in vestibule. Invoke after editing strategy, pkce, state, credentials, oidc, authorization_request, or any provider package code.
+tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# OAuth Security Reviewer (adversarial)
+
+You are a hostile attacker reading vestibule's source with one goal: **steal tokens, hijack sessions, or impersonate users**. The library is presumed insecure until you fail to break it. The author thinks the code is fine — that is precisely why they asked you to look. Your job is to be the smartest, most patient adversary they'll ever face, in writing, before a real one shows up.
+
+Scope: vestibule core (`src/vestibule/**`) and provider packages (`packages/vestibule_*/src/**`). Read-only — do not edit files.
+
+## Mindset rules
+
+- **Assume malice everywhere.** Inputs are attacker-controlled until proven otherwise: the authorize URL params, the callback query string, the token response body, the JWKS endpoint, the user-info JSON, the redirect_uri config, the host header.
+- **Compliance is not safety.** "It's RFC-compliant" / "the type system enforces it" / "the test passes" do not close a finding. State the concrete attack or concede the point.
+- **Don't accept defenses you can't see.** If a check should exist and you can't find it with `grep`, it doesn't exist. Cite the missing call site, don't assume "probably handled elsewhere."
+- **Chain weaknesses.** A single low-severity issue is often the pivot for a critical one. Look for two-step exploits: predictable state + open redirect, missing nonce + reused authorization code, leaky error type + verbose logging.
+- **Be specific or be silent.** No generic "consider hardening X." Every finding names a file, a line, an attacker, and a concrete sequence of HTTP requests or inputs that demonstrates the break. If you can't write the exploit sketch, you don't have a finding yet — keep looking or drop it.
+- **No flattery, no hedging.** Don't soften findings to be polite. Don't pad with "overall the code looks solid" — that's not your job. If the diff is genuinely clean, the verdict line says so in five words and you stop.
+
+## Inputs
+
+The invoker should tell you what to review. If they don't, default to `git diff main...HEAD -- 'src/**/*.gleam' 'packages/**/*.gleam'` plus any unstaged changes from `git diff` / `git diff --staged`.
+
+## Process
+
+1. Identify what changed and what each file does (strategy contract, PKCE, state/CSRF, credentials, OIDC verification, redirect handling, provider implementation).
+2. For each changed file, run the checks below — but treat them as *prompts for attacks*, not boxes to tick. The checklist is the floor, not the ceiling. If you spot something off-checklist, chase it.
+3. For every suspected weakness, write the exploit sketch *before* you write the finding. If the sketch falls apart, the finding does too.
+4. Report. Quote `file:line`. Skip checks that genuinely don't apply — but say so in one sentence so the author knows you looked.
+
+## Checklist
+
+### Authorization request construction (`authorization_request.gleam`, provider `*.gleam`)
+- [ ] `state` parameter is generated per-request via `state.generate()` (or equivalent CSPRNG), never reused, never derived from predictable input.
+- [ ] `nonce` is included for OIDC flows and tied to the ID token check.
+- [ ] PKCE `code_challenge` + `code_challenge_method=S256` are present for public clients; `plain` method is not accepted.
+- [ ] `redirect_uri` is passed through unmodified to the token exchange (RFC 6749 §4.1.3 requires byte-equality).
+- [ ] Scopes are explicit; no wildcard or accidental scope escalation.
+
+### PKCE (`pkce.gleam`)
+- [ ] Verifier is generated from `crypto.strong_random_bytes` (not `random` or time-based).
+- [ ] Verifier length is 43–128 chars after base64url encoding (RFC 7636 §4.1).
+- [ ] Challenge is SHA-256 of the verifier, base64url-encoded *without* padding.
+- [ ] Verifier is not logged, not exposed in error messages, and is dropped after exchange.
+
+### State / CSRF (`state.gleam`)
+- [ ] Comparison is constant-time (`crypto.secure_compare` or equivalent), not `==` on strings.
+- [ ] State token is ≥128 bits of entropy.
+- [ ] Returns `StateMismatch` (or comparable typed error) on failure; never logs the expected value.
+
+### Token exchange & credentials (`credentials.gleam`, strategy `exchange` impl)
+- [ ] Client secrets are read from config, never hard-coded, never logged.
+- [ ] Token response parsing uses typed decoders (`gleam/dynamic` decoders or `gleam_json`); does not silently accept unknown shapes.
+- [ ] Error paths do not include access/refresh tokens in the returned `AuthError`.
+- [ ] `Credentials` opaque type does not expose tokens via `Debug`/string formatting in user-facing code.
+- [ ] HTTP requests use TLS (`gleam_httpc` with https URLs); no http:// fallback for token endpoints.
+
+### OIDC ID token (`oidc.gleam`)
+- [ ] Signature is verified against the provider's JWKS (not skipped, not "trusted on first use").
+- [ ] `iss` matches the configured provider issuer exactly.
+- [ ] `aud` contains the configured client_id.
+- [ ] `exp` is checked; `nbf`/`iat` are checked when present, with reasonable clock skew (≤5 min).
+- [ ] `nonce` matches the one sent in the authorize request.
+- [ ] `alg=none` is rejected; algorithm is pinned per provider (Apple ES256, Google RS256, etc.).
+
+### Redirect URI handling
+- [ ] Stored redirect URIs are matched exactly (no prefix match, no wildcard).
+- [ ] Open-redirect risk: app-controlled "return_to" / "next" params are validated against an allowlist before any redirect.
+
+### Logging & error messages (`error.gleam`, all modules)
+- [ ] No `io.println` / `wisp.log_*` calls that interpolate `Credentials`, raw token strings, `client_secret`, code verifiers, or authorization codes.
+- [ ] Error variants don't carry sensitive material in fields that get rendered to the user.
+
+### Provider packages (`packages/vestibule_*/src/**`)
+- [ ] User-info endpoints are hit with `Authorization: Bearer <token>` over TLS, not via query string.
+- [ ] Provider-specific quirks are documented (e.g., Apple's `form_post` response mode, Microsoft's tenant-restricted issuer).
+- [ ] No copy-paste drift between provider implementations of the same security check.
+
+### Cross-cutting
+- [ ] Run `grep -rni 'TODO\|FIXME\|XXX' src packages | grep -i 'secur\|auth\|token\|secret'` — surface any auth-related TODOs touched by the diff.
+- [ ] Run `grep -rn 'strong_random_bytes\|secure_compare' src packages` and confirm any new randomness/comparison goes through these.
+
+## Reporting format
+
+Group findings by severity. For each:
+
+```
+[severity] file.gleam:line — short title
+  Claim: the precise defect, in one sentence.
+  Attacker: who they are and what they already have (a phished link click, a malicious provider response, a stolen authorization code, MITM on a non-TLS hop, control of a sibling subdomain, etc.).
+  Exploit: numbered steps. Concrete inputs. The HTTP requests they send, the values they substitute, the response they win. If you can't write this, you don't have a finding.
+  Impact: what they get (account takeover, token theft, victim's session, silent privilege grant).
+  Fix: one line. Name the function or check that should exist.
+```
+
+Severities — assign by *exploitability*, not by how it feels:
+- **critical** — exploit works against a default-configured deployment with no insider access. Examples: missing ID-token signature verification, `==` string comparison on state, tokens logged at info level.
+- **high** — exploit requires one realistic precondition (phishing click, a malicious provider, attacker-chosen redirect_uri the app accepts). Examples: missing nonce check, open redirect, weak state entropy.
+- **medium** — exploit requires chaining with another bug, or only works in narrow configurations. Examples: missing `iat` check, error variants that leak structure, non-constant-time compare on a non-secret.
+- **low** — hygiene, defense-in-depth, or future-proofing. No standalone exploit path.
+
+End with a one-line verdict — and pick the harshest one that's honest:
+- `Ship it. I couldn't break it.`
+- `Fix [N] critical/high before merge. Specifics above.`
+- `Don't merge. Architectural issue — see [finding].`
+- `Inconclusive — need clarification on [X] before I can rule out [attack].`
+
+If the diff doesn't touch security-relevant code, say so in one sentence and stop. Don't invent findings to look busy.

--- a/.claude/hooks/block-secrets.sh
+++ b/.claude/hooks/block-secrets.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+FILE_PATH=$(jq -r '.tool_input.file_path' < /dev/stdin)
+
+if [ -z "$FILE_PATH" ] || [ "$FILE_PATH" = "null" ]; then
+  exit 0
+fi
+
+BASENAME=$(basename "$FILE_PATH")
+
+case "$BASENAME" in
+  .env.example|.env.sample|.env.template|.env.dist)
+    exit 0
+    ;;
+esac
+
+case "$FILE_PATH" in
+  *.env|*/.env|*.env.local|*.env.*.local|*.env.production|*.env.development)
+    echo '{"decision":"block","reason":"Refusing to edit .env file. These typically contain real OAuth client secrets or tokens. Edit by hand, or use .env.example for templates."}'
+    exit 0
+    ;;
+  *private_key*|*.pem|*.p12|*.pfx|*.jks|*id_rsa*|*id_ed25519*)
+    echo '{"decision":"block","reason":"Refusing to edit what looks like a private key or certificate file. If this is intentional, edit it outside Claude."}'
+    exit 0
+    ;;
+esac
+
+case "$BASENAME" in
+  *secret*|*credential*|*[Tt]oken.json|*[Tt]oken.txt)
+    case "$BASENAME" in
+      *secret*.gleam|*credential*.gleam|*secret*.md|*credential*.md|*_test.gleam|*test_*.gleam)
+        exit 0
+        ;;
+    esac
+    echo '{"decision":"block","reason":"Refusing to edit a file that looks like it holds secrets/credentials/tokens. If this is a source file, rename it; if it really holds secrets, edit it outside Claude."}'
+    exit 0
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-manifest.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-secrets.sh",
+            "timeout": 5
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ let assert Ok(auth) =
     "code verifier from session",
   )
 // Delete the stored state and code verifier after a successful callback.
-// auth.uid, auth.info.email, auth.credentials.token
+// auth.uid, auth.info.email, credentials.token(auth.credentials)
 ```
 
 Store `state` and the PKCE `code_verifier` on the server, bound to the user's

--- a/docs/guides/writing-a-custom-strategy.md
+++ b/docs/guides/writing-a-custom-strategy.md
@@ -306,7 +306,7 @@ fn parse_success_token(body: String) -> Result(Credentials, AuthError(e)) {
       decode.optional(decode.string),
     )
     use scope <- decode.optional_field("scope", [], decode.list(decode.string))
-    decode.success(Credentials(
+    decode.success(credentials.new(
       token: access_token,
       refresh_token: refresh_token,
       token_type: token_type,
@@ -761,7 +761,7 @@ import gleam/dict
 import gleam/option.{None, Some}
 import startest
 import startest/expect
-import vestibule/credentials.{Credentials}
+import vestibule/credentials
 import vestibule_twitch
 
 pub fn main() -> Nil {
@@ -774,7 +774,7 @@ pub fn parse_token_response_success_test() {
   vestibule_twitch.parse_token_response(body)
   |> expect.to_be_ok()
   |> expect.to_equal(
-    Credentials(
+    credentials.new(
       token: "cfabdegwdoklmawdzdo98xt2fo512y",
       refresh_token: Some("eyJfMzUtNDU0OC04MWYwLTQ5MDY5ODY4NGNlMSJ9"),
       token_type: "bearer",

--- a/packages/vestibule_apple/src/vestibule_apple.gleam
+++ b/packages/vestibule_apple/src/vestibule_apple.gleam
@@ -27,6 +27,7 @@
 //// let apple = vestibule_apple.init()
 //// let strategy = vestibule_apple.strategy(apple)
 //// ```
+
 import gleam/dict
 import gleam/dynamic
 import gleam/dynamic/decode
@@ -47,7 +48,7 @@ import glow_auth/token_request
 import glow_auth/uri/uri_builder
 
 import vestibule/config.{type Config}
-import vestibule/credentials.{type Credentials, Credentials}
+import vestibule/credentials
 import vestibule/error.{type AuthError}
 import vestibule/provider_support
 import vestibule/strategy.{type ExchangeResult, type Strategy, type UserResult}
@@ -162,7 +163,7 @@ fn parse_success_token(body: String) -> Result(ExchangeResult, AuthError(e)) {
       s -> string.split(s, " ")
     }
     decode.success(#(
-      Credentials(
+      credentials.new(
         token: access_token,
         refresh_token: refresh_token,
         token_type: token_type,
@@ -373,7 +374,7 @@ fn do_exchange_code(
 fn do_refresh_token(
   cfg: Config,
   refresh_tok: String,
-) -> Result(Credentials, AuthError(e)) {
+) -> Result(credentials.Credentials, AuthError(e)) {
   use site <- result.try(
     uri.parse("https://appleid.apple.com")
     |> result.map_error(fn(_) {

--- a/packages/vestibule_apple/src/vestibule_apple/jwks.gleam
+++ b/packages/vestibule_apple/src/vestibule_apple/jwks.gleam
@@ -3,6 +3,7 @@
 //// Fetches Apple's public keys from `https://appleid.apple.com/auth/keys`
 //// and caches them in a bravo ETS table for reuse. Keys are used to verify
 //// the signature of Apple's ID token JWTs.
+
 import bravo
 import bravo/uset.{type USet}
 import gleam/http/request

--- a/packages/vestibule_apple/src/vestibule_apple/jwt.gleam
+++ b/packages/vestibule_apple/src/vestibule_apple/jwt.gleam
@@ -3,6 +3,7 @@
 //// This replaces ywt_erlang to avoid an OTP 27 compatibility issue in
 //// its EC key generation. We only need verification (not key generation)
 //// for production use, plus HMAC signing for tests.
+
 import gleam/crypto
 import gleam/dynamic/decode.{type Decoder}
 import gleam/json

--- a/packages/vestibule_apple/test/vestibule_apple_test.gleam
+++ b/packages/vestibule_apple/test/vestibule_apple_test.gleam
@@ -4,8 +4,8 @@ import gleam/option.{None, Some}
 import startest
 import startest/expect
 import vestibule/config
+import vestibule/credentials
 import vestibule/strategy
-import vestibule/credentials.{Credentials}
 import vestibule_apple
 import vestibule_apple/jwks
 
@@ -16,8 +16,7 @@ pub fn main() -> Nil {
 // --- Strategy construction ---
 
 fn test_apple_cache(name: String) -> vestibule_apple.AppleCache {
-  let assert Ok(cache) =
-    vestibule_apple.try_init_named("apple_test_" <> name)
+  let assert Ok(cache) = vestibule_apple.try_init_named("apple_test_" <> name)
   cache
 }
 
@@ -55,7 +54,7 @@ pub fn parse_token_response_success_test() {
   let assert Ok(exchange) = vestibule_apple.parse_token_response(body)
   strategy.exchange_credentials(exchange)
   |> expect.to_equal(
-    Credentials(
+    credentials.new(
       token: "a1b2c3.test_access_token",
       refresh_token: Some("r4e5f6.test_refresh"),
       token_type: "Bearer",
@@ -63,7 +62,8 @@ pub fn parse_token_response_success_test() {
       scopes: [],
     ),
   )
-  let assert Ok(id_token) = dict.get(strategy.exchange_artifacts(exchange), "id_token")
+  let assert Ok(id_token) =
+    dict.get(strategy.exchange_artifacts(exchange), "id_token")
   decode.run(id_token, decode.string)
   |> expect.to_equal(Ok("header.payload.signature"))
 }
@@ -72,9 +72,14 @@ pub fn parse_token_response_without_refresh_token_test() {
   let body =
     "{\"access_token\":\"test_token\",\"token_type\":\"Bearer\",\"expires_in\":3600,\"id_token\":\"h.p.s\"}"
   let assert Ok(exchange) = vestibule_apple.parse_token_response(body)
-  strategy.exchange_credentials(exchange).token |> expect.to_equal("test_token")
-  strategy.exchange_credentials(exchange).refresh_token |> expect.to_equal(None)
-  let assert Ok(id_token) = dict.get(strategy.exchange_artifacts(exchange), "id_token")
+  strategy.exchange_credentials(exchange)
+  |> credentials.token()
+  |> expect.to_equal("test_token")
+  strategy.exchange_credentials(exchange)
+  |> credentials.refresh_token()
+  |> expect.to_equal(None)
+  let assert Ok(id_token) =
+    dict.get(strategy.exchange_artifacts(exchange), "id_token")
   decode.run(id_token, decode.string) |> expect.to_equal(Ok("h.p.s"))
 }
 
@@ -82,15 +87,20 @@ pub fn parse_token_response_without_id_token_test() {
   let body =
     "{\"access_token\":\"test_token\",\"token_type\":\"Bearer\",\"expires_in\":3600}"
   let assert Ok(exchange) = vestibule_apple.parse_token_response(body)
-  strategy.exchange_credentials(exchange).token |> expect.to_equal("test_token")
-  dict.get(strategy.exchange_artifacts(exchange), "id_token") |> expect.to_be_error()
+  strategy.exchange_credentials(exchange)
+  |> credentials.token()
+  |> expect.to_equal("test_token")
+  dict.get(strategy.exchange_artifacts(exchange), "id_token")
+  |> expect.to_be_error()
 }
 
 pub fn parse_token_response_empty_scope_test() {
   let body =
     "{\"access_token\":\"test_token\",\"token_type\":\"Bearer\",\"expires_in\":3600,\"scope\":\"\"}"
   let assert Ok(exchange) = vestibule_apple.parse_token_response(body)
-  strategy.exchange_credentials(exchange).scopes |> expect.to_equal([])
+  strategy.exchange_credentials(exchange)
+  |> credentials.scopes()
+  |> expect.to_equal([])
 }
 
 pub fn parse_token_response_error_test() {

--- a/packages/vestibule_google/src/vestibule_google.gleam
+++ b/packages/vestibule_google/src/vestibule_google.gleam
@@ -219,9 +219,9 @@ fn do_fetch_user(
   _cfg: Config,
   exchange: strategy.ExchangeResult,
 ) -> Result(UserResult, AuthError(e)) {
-  use auth_header <- result.try(strategy.authorization_header(
-    strategy.exchange_credentials(exchange),
-  ))
+  use auth_header <- result.try(
+    strategy.authorization_header(strategy.exchange_credentials(exchange)),
+  )
   use #(uid, info) <- result.try(provider_support.fetch_json_with_auth(
     "https://www.googleapis.com/oauth2/v3/userinfo",
     auth_header,

--- a/packages/vestibule_google/test/vestibule_google_test.gleam
+++ b/packages/vestibule_google/test/vestibule_google_test.gleam
@@ -3,9 +3,9 @@ import gleam/string
 import startest
 import startest/expect
 import vestibule/config
-import vestibule/credentials.{Credentials}
-import vestibule/strategy
+import vestibule/credentials
 import vestibule/error
+import vestibule/strategy
 import vestibule_google
 
 pub fn main() -> Nil {
@@ -18,7 +18,7 @@ pub fn parse_token_response_success_test() {
   vestibule_google.parse_token_response(body)
   |> expect.to_be_ok()
   |> expect.to_equal(
-    Credentials(
+    credentials.new(
       token: "ya29.test_token",
       refresh_token: None,
       token_type: "Bearer",
@@ -38,7 +38,7 @@ pub fn parse_token_response_with_refresh_token_test() {
   vestibule_google.parse_token_response(body)
   |> expect.to_be_ok()
   |> expect.to_equal(
-    Credentials(
+    credentials.new(
       token: "ya29.test",
       refresh_token: Some("1//test_refresh"),
       token_type: "Bearer",
@@ -51,8 +51,8 @@ pub fn parse_token_response_with_refresh_token_test() {
 pub fn parse_token_response_empty_scope_test() {
   let body =
     "{\"access_token\":\"ya29.test\",\"expires_in\":3600,\"scope\":\"\",\"token_type\":\"Bearer\"}"
-  let assert Ok(credentials) = vestibule_google.parse_token_response(body)
-  credentials.scopes |> expect.to_equal([])
+  let assert Ok(creds) = vestibule_google.parse_token_response(body)
+  credentials.scopes(creds) |> expect.to_equal([])
 }
 
 pub fn parse_token_response_error_test() {
@@ -122,6 +122,7 @@ pub fn authorize_url_includes_extra_params_test() {
   let assert Ok(conf) =
     config.new("client-id", "secret", "http://localhost/callback")
     |> config.with_extra_params([#("prompt", "consent")])
-  let assert Ok(url) = strategy.build_authorize_url(strat, conf, ["openid"], "state")
+  let assert Ok(url) =
+    strategy.build_authorize_url(strat, conf, ["openid"], "state")
   { string.contains(url, "prompt=consent") } |> expect.to_be_true()
 }

--- a/packages/vestibule_microsoft/test/vestibule_microsoft_test.gleam
+++ b/packages/vestibule_microsoft/test/vestibule_microsoft_test.gleam
@@ -3,7 +3,7 @@ import gleam/string
 import startest
 import startest/expect
 import vestibule/config
-import vestibule/credentials.{Credentials}
+import vestibule/credentials
 import vestibule/strategy
 import vestibule_microsoft
 
@@ -17,7 +17,7 @@ pub fn parse_token_response_success_test() {
   vestibule_microsoft.parse_token_response(body)
   |> expect.to_be_ok()
   |> expect.to_equal(
-    Credentials(
+    credentials.new(
       token: "eyJ0eXAi_test_token",
       refresh_token: Some("AwABAAAA_test_refresh"),
       token_type: "Bearer",
@@ -33,7 +33,7 @@ pub fn parse_token_response_without_refresh_token_test() {
   vestibule_microsoft.parse_token_response(body)
   |> expect.to_be_ok()
   |> expect.to_equal(
-    Credentials(
+    credentials.new(
       token: "test_token",
       refresh_token: None,
       token_type: "Bearer",
@@ -46,8 +46,8 @@ pub fn parse_token_response_without_refresh_token_test() {
 pub fn parse_token_response_empty_scope_test() {
   let body =
     "{\"token_type\":\"Bearer\",\"scope\":\"\",\"expires_in\":3600,\"access_token\":\"test_token\"}"
-  let assert Ok(credentials) = vestibule_microsoft.parse_token_response(body)
-  credentials.scopes |> expect.to_equal([])
+  let assert Ok(creds) = vestibule_microsoft.parse_token_response(body)
+  credentials.scopes(creds) |> expect.to_equal([])
 }
 
 pub fn parse_token_response_error_test() {

--- a/packages/vestibule_wisp/README.md
+++ b/packages/vestibule_wisp/README.md
@@ -119,6 +119,11 @@ case vestibule_wisp.callback_phase_auth_result(req, reg, provider, store) {
 }
 ```
 
+`callback_phase` renders a generic authentication failure page on error so
+provider-controlled error descriptions are not reflected to users. Use
+`callback_phase_auth_result` or `callback_phase_auth_result_with_options` when
+the application needs structured error details for logging or custom rendering.
+
 Malformed provider responses and missing `state` or `code` parameters are
 reported through `AuthFailed`. `InvalidCallbackParams` is returned when callback
 parameters cannot be extracted from the request, such as malformed POST form

--- a/packages/vestibule_wisp/src/vestibule_wisp.gleam
+++ b/packages/vestibule_wisp/src/vestibule_wisp.gleam
@@ -9,9 +9,7 @@
 import gleam/bit_array
 import gleam/dict
 import gleam/http
-import gleam/int
 import gleam/result
-import gleam/string
 import gleam/uri
 import wisp.{type Request, type Response}
 
@@ -324,38 +322,16 @@ fn callback_error_response(err: CallbackError(e)) -> Response {
   }
 }
 
-fn error_response(err: error.AuthError(e)) -> Response {
-  let message = case err {
-    error.StateMismatch -> "State mismatch — possible CSRF attack"
-    error.MissingCallbackParam(name:) -> "Missing callback parameter: " <> name
-    error.CodeExchangeFailed(reason:) -> "Code exchange failed: " <> reason
-    error.UserInfoFailed(reason:) -> "User info fetch failed: " <> reason
-    error.ProviderError(code:, description:, uri: _) ->
-      "Provider error [" <> code <> "]: " <> description
-    error.HttpError(status:, body:) ->
-      "Provider HTTP error [" <> int.to_string(status) <> "]: " <> body
-    error.DecodeError(context:, reason:) ->
-      "Failed to decode " <> context <> ": " <> reason
-    error.NetworkError(reason:) -> "Network error: " <> reason
-    error.ConfigError(reason:) -> "Configuration error: " <> reason
-    error.Custom(_) -> "Custom provider error"
-  }
-  let safe_message = html_escape(message)
-  wisp.html_response("<html>
+fn error_response(_err: error.AuthError(e)) -> Response {
+  wisp.html_response(
+    "<html>
 <head><title>Authentication Error</title></head>
 <body style=\"font-family: system-ui, sans-serif; max-width: 600px; margin: 80px auto;\">
   <h1>Authentication Failed</h1>
-  <p style=\"color: #c0392b;\">" <> safe_message <> "</p>
+  <p style=\"color: #c0392b;\">Authentication failed. Please try again.</p>
   <a href=\"/\">Try again</a>
 </body>
-</html>", 400)
-}
-
-fn html_escape(text: String) -> String {
-  text
-  |> string.replace("&", "&amp;")
-  |> string.replace("<", "&lt;")
-  |> string.replace(">", "&gt;")
-  |> string.replace("\"", "&quot;")
-  |> string.replace("'", "&#x27;")
+</html>",
+    400,
+  )
 }

--- a/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
+++ b/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
@@ -1,4 +1,5 @@
 import gleam/http
+import gleam/option
 import gleam/string
 import startest
 import startest/expect
@@ -208,9 +209,78 @@ fn test_strategy() -> Strategy(e) {
   )
 }
 
+fn leaky_error_strategy() -> Strategy(e) {
+  strategy.new(
+    provider: "test",
+    default_scopes: [],
+    authorize_url: fn(_config, _scopes, _state) { Ok("https://example.com") },
+    exchange_code: fn(_config, _code, _code_verifier) {
+      Error(error.ProviderError(
+        code: "invalid_request",
+        description: "provider-controlled phishing text secret-token",
+        uri: option.None,
+      ))
+    },
+    refresh_token: fn(_config, _refresh_token) {
+      Error(error.ConfigError(reason: "test"))
+    },
+    fetch_user: fn(_config, _exchange) {
+      Error(error.ConfigError(reason: "test"))
+    },
+  )
+}
+
 fn test_config() -> config.Config {
   config.new("client_id", "client_secret", "https://example.com/callback")
 }
 
 @external(erlang, "vestibule_wisp_state_store_test_ffi", "state_store_survives_creator_process_exit")
 fn state_store_survives_creator_process_exit() -> Bool
+
+pub fn callback_phase_default_error_response_does_not_render_provider_details_test() {
+  let store = state_store.init_named("test_callback_generic_error_html")
+  let session_id = state_store.store(store, "state", "verifier")
+  let req =
+    simulate.request(http.Get, "/auth/test/callback?state=state&code=code")
+    |> simulate.cookie("vestibule_session", session_id, wisp.Signed)
+  let reg =
+    registry.new()
+    |> registry.register(leaky_error_strategy(), test_config())
+
+  let response =
+    vestibule_wisp.callback_phase(req, reg, "test", store, fn(_auth) {
+      wisp.html_response("success", 200)
+    })
+
+  response.status |> expect.to_equal(400)
+  let body = case response.body {
+    wisp.Text(body) -> body
+    _ -> panic as "expected text response body"
+  }
+  { string.contains(body, "secret-token") } |> expect.to_be_false()
+  { string.contains(body, "provider-controlled phishing text") }
+  |> expect.to_be_false()
+  { string.contains(body, "Authentication failed") } |> expect.to_be_true()
+}
+
+pub fn callback_phase_auth_result_preserves_provider_error_details_test() {
+  let store = state_store.init_named("test_callback_structured_error_details")
+  let session_id = state_store.store(store, "state", "verifier")
+  let req =
+    simulate.request(http.Get, "/auth/test/callback?state=state&code=code")
+    |> simulate.cookie("vestibule_session", session_id, wisp.Signed)
+  let reg =
+    registry.new()
+    |> registry.register(leaky_error_strategy(), test_config())
+
+  vestibule_wisp.callback_phase_auth_result(req, reg, "test", store)
+  |> expect.to_equal(
+    Error(
+      vestibule_wisp.AuthFailed(error.ProviderError(
+        code: "invalid_request",
+        description: "provider-controlled phishing text secret-token",
+        uri: option.None,
+      )),
+    ),
+  )
+}

--- a/src/vestibule/credentials.gleam
+++ b/src/vestibule/credentials.gleam
@@ -5,15 +5,16 @@
 //// > Treat them like passwords — never log them, never include them in
 //// > error reports, and store them encrypted at rest.
 
-import gleam/option.{type Option}
+import gleam/int
+import gleam/option.{type Option, None, Some}
+import gleam/string
 
 /// OAuth credentials from the provider.
 ///
-/// **Security warning:** This type contains sensitive tokens. Avoid logging
-/// or debugging `Credentials` values — `io.debug()` will print the access
-/// token and refresh token in plain text. Store tokens securely and treat
-/// them as secrets.
-pub type Credentials {
+/// Opaque so raw access and refresh tokens are not exposed through pattern
+/// matching or casual field access. Use `new` to construct credentials in
+/// strategies and accessors to read fields when needed.
+pub opaque type Credentials {
   Credentials(
     token: String,
     refresh_token: Option(String),
@@ -23,4 +24,67 @@ pub type Credentials {
     expires_in: Option(Int),
     scopes: List(String),
   )
+}
+
+/// Construct OAuth credentials from a provider token response.
+pub fn new(
+  token token: String,
+  refresh_token refresh_token: Option(String),
+  token_type token_type: String,
+  expires_in expires_in: Option(Int),
+  scopes scopes: List(String),
+) -> Credentials {
+  Credentials(
+    token: token,
+    refresh_token: refresh_token,
+    token_type: token_type,
+    expires_in: expires_in,
+    scopes: scopes,
+  )
+}
+
+/// Return the access token.
+pub fn token(credentials: Credentials) -> String {
+  credentials.token
+}
+
+/// Return the refresh token, when the provider supplied one.
+pub fn refresh_token(credentials: Credentials) -> Option(String) {
+  credentials.refresh_token
+}
+
+/// Return the token type, usually `Bearer`.
+pub fn token_type(credentials: Credentials) -> String {
+  credentials.token_type
+}
+
+/// Return the provider-reported lifetime in seconds.
+pub fn expires_in(credentials: Credentials) -> Option(Int) {
+  credentials.expires_in
+}
+
+/// Return the scopes granted by the provider.
+pub fn scopes(credentials: Credentials) -> List(String) {
+  credentials.scopes
+}
+
+/// Return a human-readable representation that never includes token values.
+pub fn redacted(credentials: Credentials) -> String {
+  let refresh = case credentials.refresh_token {
+    Some(_) -> "present"
+    None -> "absent"
+  }
+  let expires = case credentials.expires_in {
+    Some(seconds) -> int.to_string(seconds)
+    None -> "unknown"
+  }
+  "Credentials(token: [REDACTED], refresh_token: "
+  <> refresh
+  <> ", token_type: "
+  <> credentials.token_type
+  <> ", expires_in: "
+  <> expires
+  <> ", scopes: ["
+  <> string.join(credentials.scopes, ", ")
+  <> "])"
 }

--- a/src/vestibule/provider_support.gleam
+++ b/src/vestibule/provider_support.gleam
@@ -11,7 +11,7 @@ import gleam/string
 import gleam/uri
 import vestibule/error.{type AuthError}
 
-import vestibule/credentials.{type Credentials, Credentials}
+import vestibule/credentials
 
 /// Check that an HTTP response has a 2xx status code.
 /// Returns the response body on success, or an HttpError on failure.
@@ -79,6 +79,7 @@ pub fn fetch_json_with_auth(
   parse: fn(String) -> Result(a, AuthError(e)),
   provider_name: String,
 ) -> Result(a, AuthError(e)) {
+  use _ <- result.try(require_https(url))
   use req <- result.try(
     request.to(url)
     |> result.map_error(fn(_) {
@@ -198,7 +199,7 @@ pub type ScopeParsing {
 pub fn parse_oauth_token_response(
   body: String,
   scope_parsing: ScopeParsing,
-) -> Result(Credentials, AuthError(e)) {
+) -> Result(credentials.Credentials, AuthError(e)) {
   use body <- result.try(check_token_error(body))
   parse_oauth_token_success(body, scope_parsing)
 }
@@ -206,7 +207,7 @@ pub fn parse_oauth_token_response(
 fn parse_oauth_token_success(
   body: String,
   scope_parsing: ScopeParsing,
-) -> Result(Credentials, AuthError(e)) {
+) -> Result(credentials.Credentials, AuthError(e)) {
   let decoder = {
     use access_token <- decode.field("access_token", decode.string)
     use token_type <- decode.field("token_type", decode.string)
@@ -245,7 +246,7 @@ fn decode_token_credentials(
   token_type: String,
   expires_in: option.Option(Int),
   scope_parsing: ScopeParsing,
-) -> decode.Decoder(Credentials) {
+) -> decode.Decoder(credentials.Credentials) {
   case scope_parsing {
     RequiredScope(separator) -> {
       use scope <- decode.field("scope", decode.string)
@@ -286,8 +287,8 @@ fn token_credentials(
   token_type: String,
   expires_in: option.Option(Int),
   scopes: List(String),
-) -> Credentials {
-  Credentials(
+) -> credentials.Credentials {
+  credentials.new(
     token: access_token,
     refresh_token: refresh_token,
     token_type: token_type,

--- a/src/vestibule/strategy.gleam
+++ b/src/vestibule/strategy.gleam
@@ -14,7 +14,7 @@ import gleam/string
 import gleam/uri
 
 import vestibule/config.{type Config}
-import vestibule/credentials.{type Credentials}
+import vestibule/credentials
 import vestibule/error.{type AuthError}
 import vestibule/user_info.{type UserInfo}
 
@@ -59,24 +59,29 @@ pub fn user_result_extra(user: UserResult) -> Dict(String, Dynamic) {
 ///
 /// Opaque to keep provider-specific artifacts evolution-safe.
 pub opaque type ExchangeResult {
-  ExchangeResult(credentials: Credentials, artifacts: Dict(String, Dynamic))
+  ExchangeResult(
+    credentials: credentials.Credentials,
+    artifacts: Dict(String, Dynamic),
+  )
 }
 
 /// Build an exchange result for providers with no provider-specific artifacts.
-pub fn exchange_result(credentials: Credentials) -> ExchangeResult {
+pub fn exchange_result(credentials: credentials.Credentials) -> ExchangeResult {
   ExchangeResult(credentials: credentials, artifacts: dict.new())
 }
 
 /// Build an exchange result with provider-specific artifacts.
 pub fn exchange_result_with_artifacts(
-  credentials: Credentials,
+  credentials: credentials.Credentials,
   artifacts: Dict(String, Dynamic),
 ) -> ExchangeResult {
   ExchangeResult(credentials: credentials, artifacts: artifacts)
 }
 
 /// Return the OAuth credentials produced by the exchange.
-pub fn exchange_credentials(exchange: ExchangeResult) -> Credentials {
+pub fn exchange_credentials(
+  exchange: ExchangeResult,
+) -> credentials.Credentials {
   exchange.credentials
 }
 
@@ -105,7 +110,8 @@ pub opaque type Strategy(e) {
       Result(String, AuthError(e)),
     exchange_code: fn(Config, String, Option(String)) ->
       Result(ExchangeResult, AuthError(e)),
-    refresh_token: fn(Config, String) -> Result(Credentials, AuthError(e)),
+    refresh_token: fn(Config, String) ->
+      Result(credentials.Credentials, AuthError(e)),
     fetch_user: fn(Config, ExchangeResult) -> Result(UserResult, AuthError(e)),
   )
 }
@@ -126,7 +132,7 @@ pub fn new(
   exchange_code exchange_code: fn(Config, String, Option(String)) ->
     Result(ExchangeResult, AuthError(e)),
   refresh_token refresh_token: fn(Config, String) ->
-    Result(Credentials, AuthError(e)),
+    Result(credentials.Credentials, AuthError(e)),
   fetch_user fetch_user: fn(Config, ExchangeResult) ->
     Result(UserResult, AuthError(e)),
 ) -> Strategy(e) {
@@ -178,7 +184,7 @@ pub fn refresh_token(
   strat: Strategy(e),
   cfg: Config,
   refresh_tok: String,
-) -> Result(Credentials, AuthError(e)) {
+) -> Result(credentials.Credentials, AuthError(e)) {
   strat.refresh_token(cfg, refresh_tok)
 }
 
@@ -199,10 +205,10 @@ pub fn fetch_user(
 /// Returns `Error` if the token type is not "bearer" (case-insensitive),
 /// as vestibule only supports Bearer token authentication.
 pub fn authorization_header(
-  credentials: Credentials,
+  credentials creds: credentials.Credentials,
 ) -> Result(String, AuthError(e)) {
-  case string.lowercase(credentials.token_type) {
-    "bearer" -> Ok("Bearer " <> credentials.token)
+  case string.lowercase(credentials.token_type(creds)) {
+    "bearer" -> Ok("Bearer " <> credentials.token(creds))
     other ->
       Error(error.ConfigError(
         reason: "Unsupported token type: "

--- a/test/vestibule/oidc_test.gleam
+++ b/test/vestibule/oidc_test.gleam
@@ -3,7 +3,7 @@ import gleam/option.{None, Some}
 import gleam/string
 import startest/expect
 import vestibule/config
-import vestibule/credentials.{Credentials}
+import vestibule/credentials
 import vestibule/error
 import vestibule/oidc
 import vestibule/strategy
@@ -175,7 +175,7 @@ pub fn parse_token_response_success_test() {
   oidc.parse_token_response(json)
   |> expect.to_be_ok()
   |> expect.to_equal(
-    Credentials(
+    credentials.new(
       token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9",
       refresh_token: Some("dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4"),
       token_type: "Bearer",
@@ -190,7 +190,7 @@ pub fn parse_token_response_minimal_test() {
   oidc.parse_token_response(json)
   |> expect.to_be_ok()
   |> expect.to_equal(
-    Credentials(
+    credentials.new(
       token: "abc123",
       refresh_token: None,
       token_type: "bearer",
@@ -203,8 +203,8 @@ pub fn parse_token_response_minimal_test() {
 pub fn parse_token_response_empty_scope_test() {
   let json =
     "{\"access_token\":\"abc123\",\"token_type\":\"Bearer\",\"scope\":\"\"}"
-  let assert Ok(credentials) = oidc.parse_token_response(json)
-  credentials.scopes |> expect.to_equal([])
+  let assert Ok(creds) = oidc.parse_token_response(json)
+  credentials.scopes(creds) |> expect.to_equal([])
 }
 
 pub fn parse_token_response_error_test() {

--- a/test/vestibule/provider_support_test.gleam
+++ b/test/vestibule/provider_support_test.gleam
@@ -2,7 +2,7 @@ import gleam/http/response
 import gleam/option.{None, Some}
 import gleam/string
 import startest/expect
-import vestibule/credentials.{Credentials}
+import vestibule/credentials
 import vestibule/error
 import vestibule/provider_support
 
@@ -153,7 +153,7 @@ pub fn parse_oauth_token_response_required_scope_success_test() {
   )
   |> expect.to_equal(
     Ok(
-      Credentials(
+      credentials.new(
         token: "tok",
         refresh_token: Some("ref"),
         token_type: "Bearer",
@@ -168,12 +168,12 @@ pub fn parse_oauth_token_response_required_scope_empty_test() {
   let body =
     "{\"access_token\":\"tok\",\"token_type\":\"Bearer\",\"scope\":\"\"}"
 
-  let assert Ok(credentials) =
+  let assert Ok(creds) =
     provider_support.parse_oauth_token_response(
       body,
       provider_support.RequiredScope(","),
     )
-  credentials.scopes |> expect.to_equal([])
+  credentials.scopes(creds) |> expect.to_equal([])
 }
 
 pub fn parse_oauth_token_response_optional_scope_missing_test() {
@@ -185,7 +185,7 @@ pub fn parse_oauth_token_response_optional_scope_missing_test() {
   )
   |> expect.to_equal(
     Ok(
-      Credentials(
+      credentials.new(
         token: "tok",
         refresh_token: None,
         token_type: "Bearer",
@@ -200,21 +200,21 @@ pub fn parse_oauth_token_response_optional_scope_empty_test() {
   let body =
     "{\"access_token\":\"tok\",\"token_type\":\"Bearer\",\"scope\":\"\"}"
 
-  let assert Ok(credentials) =
+  let assert Ok(creds) =
     provider_support.parse_oauth_token_response(
       body,
       provider_support.OptionalScope(" "),
     )
-  credentials.scopes |> expect.to_equal([])
+  credentials.scopes(creds) |> expect.to_equal([])
 }
 
 pub fn parse_oauth_token_response_no_scope_ignores_present_scope_test() {
   let body =
     "{\"access_token\":\"tok\",\"token_type\":\"Bearer\",\"scope\":\"ignored\"}"
 
-  let assert Ok(credentials) =
+  let assert Ok(creds) =
     provider_support.parse_oauth_token_response(body, provider_support.NoScope)
-  credentials.scopes |> expect.to_equal([])
+  credentials.scopes(creds) |> expect.to_equal([])
 }
 
 pub fn parse_oauth_token_response_calls_check_token_error_first_test() {
@@ -298,5 +298,24 @@ pub fn parse_oauth_token_response_required_scope_rejects_missing_scope_test() {
       string.contains(reason, "scope") |> expect.to_be_true()
     }
     _ -> panic as "expected DecodeError"
+  }
+}
+
+pub fn fetch_json_with_auth_rejects_remote_http_before_sending_token_test() {
+  let result =
+    provider_support.fetch_json_with_auth(
+      "http://example.com/userinfo",
+      "Bearer secret-token",
+      fn(_body) { Ok("parsed") },
+      "test userinfo",
+    )
+
+  case result {
+    Error(error.ConfigError(reason:)) ->
+      reason
+      |> expect.to_equal(
+        "HTTPS required for endpoint URL: http://example.com/userinfo",
+      )
+    _ -> panic as "expected ConfigError before sending bearer token"
   }
 }

--- a/test/vestibule/refresh_test.gleam
+++ b/test/vestibule/refresh_test.gleam
@@ -1,6 +1,6 @@
 import gleam/option.{None, Some}
 import startest/expect
-import vestibule/credentials.{Credentials}
+import vestibule/credentials
 import vestibule/error
 import vestibule/provider_support
 
@@ -13,7 +13,7 @@ pub fn parse_refresh_response_success_with_all_fields_test() {
   )
   |> expect.to_be_ok()
   |> expect.to_equal(
-    Credentials(
+    credentials.new(
       token: "new_access_token",
       refresh_token: Some("new_refresh_token"),
       token_type: "Bearer",
@@ -31,7 +31,7 @@ pub fn parse_refresh_response_success_minimal_test() {
   )
   |> expect.to_be_ok()
   |> expect.to_equal(
-    Credentials(
+    credentials.new(
       token: "token_abc",
       refresh_token: None,
       token_type: "bearer",
@@ -50,7 +50,7 @@ pub fn parse_refresh_response_with_refresh_token_rotation_test() {
   )
   |> expect.to_be_ok()
   |> expect.to_equal(
-    Credentials(
+    credentials.new(
       token: "rotated_access",
       refresh_token: Some("rotated_refresh"),
       token_type: "Bearer",
@@ -69,7 +69,7 @@ pub fn parse_refresh_response_rotation_without_refresh_token_test() {
   )
   |> expect.to_be_ok()
   |> expect.to_equal(
-    Credentials(
+    credentials.new(
       token: "rotated_access",
       refresh_token: None,
       token_type: "Bearer",
@@ -130,7 +130,7 @@ pub fn parse_refresh_response_without_scope_has_empty_scopes_test() {
       body,
       provider_support.OptionalScope(" "),
     )
-  creds.scopes |> expect.to_equal([])
+  credentials.scopes(creds) |> expect.to_equal([])
 }
 
 pub fn parse_refresh_response_empty_scope_has_empty_scopes_test() {
@@ -141,5 +141,5 @@ pub fn parse_refresh_response_empty_scope_has_empty_scopes_test() {
       body,
       provider_support.OptionalScope(" "),
     )
-  creds.scopes |> expect.to_equal([])
+  credentials.scopes(creds) |> expect.to_equal([])
 }

--- a/test/vestibule/security_test.gleam
+++ b/test/vestibule/security_test.gleam
@@ -10,7 +10,7 @@ import startest/expect
 import vestibule
 import vestibule/authorization_request
 import vestibule/config
-import vestibule/credentials.{Credentials}
+import vestibule/credentials
 import vestibule/error
 import vestibule/oidc
 import vestibule/pkce
@@ -40,7 +40,7 @@ fn test_strategy() -> Strategy(e) {
         "valid_code" ->
           Ok(
             strategy.exchange_result(
-              Credentials(
+              credentials.new(
                 token: "tok",
                 refresh_token: None,
                 token_type: "bearer",
@@ -370,7 +370,7 @@ pub fn refresh_response_handles_long_token_test() {
       provider_support.OptionalScope(" "),
     )
   let assert Ok(creds) = result
-  { string.length(creds.token) == 10_000 } |> expect.to_be_true()
+  { string.length(credentials.token(creds)) == 10_000 } |> expect.to_be_true()
 }
 
 // ===========================================================================

--- a/test/vestibule/strategy/github_test.gleam
+++ b/test/vestibule/strategy/github_test.gleam
@@ -3,7 +3,7 @@ import gleam/option.{None, Some}
 import gleam/string
 import startest/expect
 import vestibule/config
-import vestibule/credentials.{Credentials}
+import vestibule/credentials
 import vestibule/strategy
 import vestibule/strategy/github
 
@@ -13,7 +13,7 @@ pub fn parse_token_response_success_test() {
   github.parse_token_response(json)
   |> expect.to_be_ok()
   |> expect.to_equal(
-    Credentials(
+    credentials.new(
       token: "gho_abc123",
       refresh_token: None,
       token_type: "bearer",
@@ -28,14 +28,14 @@ pub fn parse_token_response_with_multiple_scopes_test() {
     "{\"access_token\":\"gho_abc123\",\"token_type\":\"bearer\",\"scope\":\"user:email,read:org\"}"
   let result = github.parse_token_response(json)
   let assert Ok(creds) = result
-  creds.scopes |> expect.to_equal(["user:email", "read:org"])
+  credentials.scopes(creds) |> expect.to_equal(["user:email", "read:org"])
 }
 
 pub fn parse_token_response_empty_scope_test() {
   let json =
     "{\"access_token\":\"gho_abc123\",\"token_type\":\"bearer\",\"scope\":\"\"}"
   let assert Ok(creds) = github.parse_token_response(json)
-  creds.scopes |> expect.to_equal([])
+  credentials.scopes(creds) |> expect.to_equal([])
 }
 
 pub fn parse_token_response_error_test() {

--- a/test/vestibule/strategy_test.gleam
+++ b/test/vestibule/strategy_test.gleam
@@ -1,11 +1,12 @@
 import gleam/http/request
 import gleam/option
+import gleam/string
 import startest/expect
-import vestibule/credentials.{Credentials}
+import vestibule/credentials
 import vestibule/strategy
 
 pub fn authorization_header_accepts_mixed_case_bearer_test() {
-  Credentials(
+  credentials.new(
     token: "abc",
     refresh_token: option.None,
     token_type: "BeArEr",
@@ -18,7 +19,7 @@ pub fn authorization_header_accepts_mixed_case_bearer_test() {
 
 pub fn authorization_header_rejects_unsupported_token_type_test() {
   let _ =
-    Credentials(
+    credentials.new(
       token: "abc",
       refresh_token: option.None,
       token_type: "MAC",
@@ -68,4 +69,39 @@ pub fn append_code_verifier_none_preserves_body_test() {
   |> strategy.append_code_verifier(option.None)
   |> fn(req) { req.body }
   |> expect.to_equal("grant_type=authorization_code")
+}
+
+pub fn credentials_accessors_return_token_fields_test() {
+  let creds =
+    credentials.new(
+      token: "access-token",
+      refresh_token: option.Some("refresh-token"),
+      token_type: "Bearer",
+      expires_in: option.Some(3600),
+      scopes: ["read:user"],
+    )
+
+  credentials.token(creds) |> expect.to_equal("access-token")
+  credentials.refresh_token(creds)
+  |> expect.to_equal(option.Some("refresh-token"))
+  credentials.token_type(creds) |> expect.to_equal("Bearer")
+  credentials.expires_in(creds) |> expect.to_equal(option.Some(3600))
+  credentials.scopes(creds) |> expect.to_equal(["read:user"])
+}
+
+pub fn credentials_redacted_does_not_include_token_values_test() {
+  let creds =
+    credentials.new(
+      token: "secret-access-token",
+      refresh_token: option.Some("secret-refresh-token"),
+      token_type: "Bearer",
+      expires_in: option.Some(3600),
+      scopes: ["read:user"],
+    )
+  let rendered = credentials.redacted(creds)
+
+  { string.contains(rendered, "secret-access-token") } |> expect.to_be_false()
+  { string.contains(rendered, "secret-refresh-token") } |> expect.to_be_false()
+  { string.contains(rendered, "Bearer") } |> expect.to_be_true()
+  { string.contains(rendered, "read:user") } |> expect.to_be_true()
 }

--- a/test/vestibule_test.gleam
+++ b/test/vestibule_test.gleam
@@ -8,7 +8,7 @@ import startest/expect
 import vestibule
 import vestibule/authorization_request
 import vestibule/config
-import vestibule/credentials.{Credentials}
+import vestibule/credentials
 import vestibule/error
 import vestibule/strategy.{type Strategy}
 import vestibule/user_info.{UserInfo}
@@ -35,7 +35,7 @@ fn test_strategy() -> Strategy(e) {
         "valid_code" ->
           Ok(
             strategy.exchange_result(
-              Credentials(
+              credentials.new(
                 token: "test_token",
                 refresh_token: None,
                 token_type: "bearer",
@@ -49,7 +49,7 @@ fn test_strategy() -> Strategy(e) {
     },
     refresh_token: fn(cfg, refresh_tok) {
       Ok(
-        Credentials(
+        credentials.new(
           token: "delegated:" <> refresh_tok <> ":" <> config.client_id(cfg),
           refresh_token: Some("rotated_by_strategy"),
           token_type: "bearer",
@@ -59,7 +59,8 @@ fn test_strategy() -> Strategy(e) {
       )
     },
     fetch_user: fn(_cfg, exchange) {
-      strategy.exchange_credentials(exchange).token
+      strategy.exchange_credentials(exchange)
+      |> credentials.token()
       |> expect.to_equal("test_token")
       Ok(strategy.user_result(
         uid: "user123",
@@ -88,7 +89,7 @@ fn artifact_strategy() -> Strategy(e) {
     },
     exchange_code: fn(_config, _code, _code_verifier) {
       Ok(strategy.exchange_result_with_artifacts(
-        Credentials(
+        credentials.new(
           token: "artifact_token",
           refresh_token: None,
           token_type: "bearer",
@@ -202,7 +203,7 @@ pub fn handle_callback_succeeds_with_valid_params_test() {
   auth.uid |> expect.to_equal("user123")
   auth.provider |> expect.to_equal("test")
   auth.info.name |> expect.to_equal(Some("Test User"))
-  auth.credentials.token |> expect.to_equal("test_token")
+  credentials.token(auth.credentials) |> expect.to_equal("test_token")
 }
 
 pub fn handle_callback_populates_auth_extra_from_strategy_user_result_test() {
@@ -233,7 +234,7 @@ pub fn handle_callback_passes_exchange_artifacts_to_fetch_user_test() {
     )
 
   auth.uid |> expect.to_equal("from-exchange")
-  auth.credentials.token |> expect.to_equal("artifact_token")
+  credentials.token(auth.credentials) |> expect.to_equal("artifact_token")
 }
 
 pub fn refresh_token_delegates_to_strategy_refresh_token_test() {
@@ -243,7 +244,7 @@ pub fn refresh_token_delegates_to_strategy_refresh_token_test() {
   vestibule.refresh_token(strat, conf, "refresh-123")
   |> expect.to_equal(
     Ok(
-      Credentials(
+      credentials.new(
         token: "delegated:refresh-123:client-id",
         refresh_token: Some("rotated_by_strategy"),
         token_type: "bearer",


### PR DESCRIPTION
## Summary
- make `Credentials` opaque and add constructor/accessor/redaction helpers
- require HTTPS before authenticated JSON fetches attach bearer tokens
- render generic vestibule_wisp callback error HTML while keeping structured errors available
- migrate provider packages, tests, and docs to the credential accessor API

## Validation
- `just ci-all`

## Breaking change
`Credentials` can no longer be constructed or read through public fields. Use `credentials.new` and the `credentials.*` accessors instead.
