### PR TITLE
fix(wisp): use bravo.Public for state_store ETS table

### DIFF
--- a/packages/vestibule_wisp/src/vestibule_wisp/state_store.gleam
+++ b/packages/vestibule_wisp/src/vestibule_wisp/state_store.gleam
@@ -11,13 +11,13 @@ pub type StateStore =
 /// Returns the table handle needed by store/retrieve.
 pub fn init() -> StateStore {
   let assert Ok(table) =
-    uset.new(name: "vestibule_wisp_sessions", access: bravo.Protected)
+    uset.new(name: "vestibule_wisp_sessions", access: bravo.Public)
   table
 }
 
 /// Initialize a named state store. Useful for testing with isolated tables.
 pub fn init_named(name: String) -> StateStore {
-  let assert Ok(table) = uset.new(name: name, access: bravo.Protected)
+  let assert Ok(table) = uset.new(name: name, access: bravo.Public)
   table
 }
 


### PR DESCRIPTION
Fixes #48.

The `vestibule_wisp/state_store` ETS table was created with `bravo.Protected`,
which only permits writes from the owning process. In a standard `wisp_mist`
deployment, request handlers run in per-connection processes spawned by
glisten/mist — those processes can read the table but cannot insert into it.
Every call to `request_phase` therefore 500s on the `let assert Ok(Nil) =
uset.insert(...)` in `store/3` with `AccessDenied`.

Switch both `init/0` and `init_named/1` to `bravo.Public` so any process can
write, which matches the intended semantics of a shared OAuth session store.

### Why the tests didn't catch this

The unit tests in `test/` call `store/3` directly from the test process — the
same process that called `init()`, which is the table owner. Owner writes
always succeed, so the bug is invisible in unit tests.

### Verified

Patched locally, then ran an integration test in [strata](https://github.com/tylerbutler/strata)
mounting `vestibule_wisp` at `/auth/*`:

```
$ curl -sv http://localhost:8000/auth/github
< HTTP/1.1 303 See Other
< set-cookie: vestibule_session=...; HttpOnly; SameSite=Lax
< location: https://github.com/login/oauth/authorize?...&code_challenge=...&state=...
```

### Follow-up suggested in #48

Add a real `wisp_mist` integration test that exercises `request_phase` over an
actual HTTP request, so per-process ETS access semantics are covered going
forward. Filing as a separate PR if there's interest.