### PR TITLE
feat!: add Mist transport and core state store

### DIFF
--- a/.changes/unreleased/vestibule-Added-20260523-103001.yaml
+++ b/.changes/unreleased/vestibule-Added-20260523-103001.yaml
@@ -1,0 +1,4 @@
+project: vestibule
+kind: Added
+body: '`vestibule/state_store` — the ETS-backed OAuth state store (CSRF state + PKCE verifier) is now part of core `vestibule`, shared by all transports (`vestibule_wisp`, `vestibule_mist`). API is unchanged from the previous `vestibule_wisp/state_store`.'
+time: 2026-05-23T10:30:01.000000+00:00

--- a/.changes/unreleased/vestibule-Added-20260523-103001.yaml
+++ b/.changes/unreleased/vestibule-Added-20260523-103001.yaml
@@ -1,4 +1,4 @@
 project: vestibule
 kind: Added
-body: '`vestibule/state_store` — the ETS-backed OAuth state store (CSRF state + PKCE verifier) is now part of core `vestibule`, shared by all transports (`vestibule_wisp`, `vestibule_mist`). API is unchanged from the previous `vestibule_wisp/state_store`.'
+body: '`vestibule/state_store` — the ETS-backed OAuth state store (CSRF state + PKCE verifier) is now part of core `vestibule`, shared by all transports (`vestibule_wisp`, `vestibule_mist`). It includes consume-oriented reads, richer initialization/store errors, and opportunistic cleanup of expired sessions.'
 time: 2026-05-23T10:30:01.000000+00:00

--- a/.changes/unreleased/vestibule_mist-Added-20260523-103000.yaml
+++ b/.changes/unreleased/vestibule_mist-Added-20260523-103000.yaml
@@ -1,0 +1,4 @@
+project: vestibule_mist
+kind: Added
+body: 'Initial release. Mist-native OAuth callback ergonomics: `request_phase`, `callback_phase`, `callback_phase_result`, and `callback_phase_auth_result` with parity to `vestibule_wisp`. State is persisted in the shared `vestibule/state_store` (ETS) and indexed by an HMAC-SHA256-signed session cookie. `Options` is constructed with `new_options(secret_key_base)` — the secret is mandatory, no default fallback.'
+time: 2026-05-23T10:30:00.000000+00:00

--- a/.changes/unreleased/vestibule_mist-Added-20260523-103000.yaml
+++ b/.changes/unreleased/vestibule_mist-Added-20260523-103000.yaml
@@ -1,4 +1,4 @@
 project: vestibule_mist
 kind: Added
-body: 'Initial release. Mist-native OAuth callback ergonomics: `request_phase`, `callback_phase`, `callback_phase_result`, and `callback_phase_auth_result` with parity to `vestibule_wisp`. State is persisted in the shared `vestibule/state_store` (ETS) and indexed by an HMAC-SHA256-signed session cookie. `Options` is constructed with `new_options(secret_key_base)` — the secret is mandatory, no default fallback.'
+body: 'Initial release. Mist-native OAuth callback ergonomics: `request_phase`, `callback_phase`, `callback_phase_result`, and `callback_phase_auth_result` with parity to `vestibule_wisp`. State is persisted in the shared `vestibule/state_store` (ETS) and indexed by an HMAC-SHA256-signed session cookie. `Options` is constructed with `new_options(secret_key_base)` — the secret is mandatory, cookies are secure by default, and no default secret fallback exists.'
 time: 2026-05-23T10:30:00.000000+00:00

--- a/.changes/unreleased/vestibule_wisp-Changed-20260523-103002.yaml
+++ b/.changes/unreleased/vestibule_wisp-Changed-20260523-103002.yaml
@@ -1,0 +1,4 @@
+project: vestibule_wisp
+kind: Changed
+body: '**Breaking:** `vestibule_wisp/state_store` has been removed. Import `vestibule/state_store` from core `vestibule` instead — the API is identical.'
+time: 2026-05-23T10:30:02.000000+00:00

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -25,6 +25,9 @@ projects:
     - label: vestibule_wisp
       key: vestibule_wisp
       changelog: packages/vestibule_wisp/CHANGELOG.md
+    - label: vestibule_mist
+      key: vestibule_mist
+      changelog: packages/vestibule_mist/CHANGELOG.md
 
 versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '#### {{.Kind}}'

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ import vestibule/config
 import vestibule/registry
 import vestibule/strategy/github
 import vestibule_wisp
-import vestibule_wisp/state_store
+import vestibule/state_store
 
 // Initialize once at startup
 let reg =
@@ -113,9 +113,10 @@ case wisp.path_segments(req), req.method {
 }
 ```
 
-The Wisp state store creates a named ETS table, so initialize it once per BEAM
-VM at startup. Use `state_store.try_init` if you want to handle duplicate-table
-errors explicitly.
+The state store creates a named ETS table, so initialize it once per BEAM
+VM at startup. Use `state_store.try_init` if you want to handle
+duplicate-table errors explicitly. The same store can be shared between
+`vestibule_wisp` and `vestibule_mist`.
 
 If you want to handle callback failures yourself instead of using the default
 HTML error page, use `vestibule_wisp.callback_phase_result`. Use
@@ -125,12 +126,40 @@ as `UnknownProvider`, `MissingSessionCookie`, `SessionExpired`,
 `code` values are provider/authentication failures and are reported through
 `AuthFailed`.
 
+Or use the `vestibule_mist` middleware for the same ergonomics on a plain
+mist server. Mist has no built-in signed-cookie helper, so you supply the
+secret explicitly:
+
+```gleam
+import gleam/http
+import gleam/http/request.{type Request}
+import gleam/http/response.{type Response}
+import mist.{type Connection, type ResponseData}
+import vestibule/state_store
+import vestibule_mist
+
+let assert Ok(store) = state_store.try_init()
+let options = vestibule_mist.new_options(secret_key_base)
+
+fn handle_request(req: Request(Connection)) -> Response(ResponseData) {
+  case request.path_segments(req), req.method {
+    ["auth", provider], http.Get ->
+      vestibule_mist.request_phase(req, reg, provider, store, options)
+    ["auth", provider, "callback"], http.Get
+    | ["auth", provider, "callback"], http.Post ->
+      vestibule_mist.callback_phase(req, reg, provider, store, options, on_success)
+    _, _ -> not_found()
+  }
+}
+```
+
 ## Packages
 
 | Package | Description | Install |
 |---------|-------------|---------|
-| `vestibule` | Core types, two-phase OAuth2 flow, PKCE, token refresh | `gleam add vestibule` |
+| `vestibule` | Core types, two-phase OAuth2 flow, PKCE, token refresh, shared state store | `gleam add vestibule` |
 | `vestibule_wisp` | Wisp middleware for request/callback routing | `gleam add vestibule_wisp` |
+| `vestibule_mist` | Mist middleware for request/callback routing | `gleam add vestibule_mist` |
 | `vestibule_google` | Google OAuth strategy | `gleam add vestibule_google` |
 | `vestibule_microsoft` | Microsoft OAuth strategy | `gleam add vestibule_microsoft` |
 | `vestibule_apple` | Apple Sign In strategy | `gleam add vestibule_apple` |

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ fn handle_request(req: Request(Connection)) -> Response(ResponseData) {
 }
 ```
 
+`vestibule_mist` sets its signed session cookie with `Secure` by default. Its
+structured cookie/session errors are named `MissingOrInvalidSessionCookie` and
+`SessionUnavailable`.
+
 ## Packages
 
 | Package | Description | Install |

--- a/example/src/router.gleam
+++ b/example/src/router.gleam
@@ -4,7 +4,7 @@ import wisp.{type Request, type Response}
 import pages
 import vestibule/registry.{type Registry}
 import vestibule_wisp
-import vestibule_wisp/state_store.{type StateStore}
+import vestibule/state_store.{type StateStore}
 
 /// Application context passed to the router.
 pub type Context(e) {

--- a/example/src/vestibule_example.gleam
+++ b/example/src/vestibule_example.gleam
@@ -13,7 +13,7 @@ import vestibule/registry
 import vestibule/strategy/github
 import vestibule_google
 import vestibule_microsoft
-import vestibule_wisp/state_store
+import vestibule/state_store
 
 pub fn main() {
   let port =

--- a/gleam.toml
+++ b/gleam.toml
@@ -13,6 +13,7 @@ gleam_crypto = ">= 1.5.0 and < 2.0.0"
 gleam_http = ">= 4.3.0 and < 5.0.0"
 gleam_httpc = ">= 5.0.0 and < 6.0.0"
 gleam_json = ">= 3.1.0 and < 4.0.0"
+gleam_time = ">= 1.7.0 and < 2.0.0"
 glow_auth = ">= 1.0.1 and < 2.0.0"
 
 [dev-dependencies]

--- a/packages/vestibule_mist/CHANGELOG.md
+++ b/packages/vestibule_mist/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/packages/vestibule_mist/README.md
+++ b/packages/vestibule_mist/README.md
@@ -1,0 +1,151 @@
+# vestibule_mist
+
+Mist middleware for vestibule's OAuth request and callback phases.
+
+## Install
+
+```sh
+gleam add vestibule
+gleam add vestibule_mist
+gleam add mist
+gleam add vestibule_google # or another vestibule provider package
+```
+
+`vestibule_mist` depends on `vestibule` and `mist`, plus at least one
+provider package.
+
+## Configure a signed-cookie secret
+
+Mist has no built-in signed-cookie helper, so `vestibule_mist` ships its own
+HMAC-SHA256 cookie signing. You **must** supply a strong, stable secret key
+base when building `Options`:
+
+```gleam
+let options = vestibule_mist.new_options(secret_key_base)
+```
+
+There is no `default_options/0` — the secret has no safe default. Use a
+high-entropy value (e.g. 64+ random bytes) and load it from configuration or
+a secrets manager.
+
+If the secret changes, existing OAuth callbacks cannot read the signed
+session cookie and will return `MissingSessionCookie`.
+
+## What it does
+
+- redirects users to the configured provider
+- stores CSRF state and PKCE verifier for the callback
+- handles both `GET` and `POST` callbacks
+- sets an HMAC-SHA256-signed session cookie with a default 600-second TTL
+- enforces server-side state-store expiry with the same TTL
+- exposes default response helpers and structured callback errors
+
+## Router shape
+
+Initialize the state store once per BEAM VM at application startup:
+
+```gleam
+import vestibule/state_store
+
+let assert Ok(store) = state_store.try_init()
+let options = vestibule_mist.new_options(secret_key_base)
+```
+
+Then dispatch from your mist handler:
+
+```gleam
+fn handle_request(req: Request(Connection)) -> Response(ResponseData) {
+  case request.path_segments(req), req.method {
+    ["auth", provider], http.Get ->
+      vestibule_mist.request_phase(req, reg, provider, store, options)
+
+    ["auth", provider, "callback"], http.Get
+    | ["auth", provider, "callback"], http.Post ->
+      vestibule_mist.callback_phase(
+        req,
+        reg,
+        provider,
+        store,
+        options,
+        on_success,
+      )
+
+    _, _ -> not_found()
+  }
+}
+```
+
+## Options
+
+`Options` carries the secret plus cookie configuration. Override fields with
+record-update syntax:
+
+```gleam
+let options =
+  vestibule_mist.Options(
+    ..vestibule_mist.new_options(secret_key_base),
+    cookie_name: "my_app_oauth_session",
+    session_ttl_seconds: 300,
+  )
+```
+
+Defaults match `vestibule_wisp`: cookie name `vestibule_session`, TTL 600
+seconds. The cookie TTL and server-side state-store TTL share the same
+value. The cookie is set with `HttpOnly`, `SameSite=Lax`, `Path=/`, and
+`Secure` when the request was made over HTTPS.
+
+If the signed cookie is missing, invalid, or signed with a different
+secret, the structured API returns `MissingSessionCookie`. If the cookie is
+valid but the stored state is missing, expired, or already used, it returns
+`SessionExpired`.
+
+## Callback error handling
+
+`vestibule_mist` exposes three callback helpers:
+
+- `callback_phase` returns a mist `Response(ResponseData)`; failures use
+  the default HTML error response.
+- `callback_phase_result` returns `Result(Auth, Response(ResponseData))`;
+  failures are still generated mist responses.
+- `callback_phase_auth_result` returns `Result(Auth, CallbackError(e))`;
+  use this for structured/custom error handling.
+
+```gleam
+case vestibule_mist.callback_phase_auth_result(req, reg, provider, store, options) {
+  Ok(auth) -> on_success(auth)
+  Error(vestibule_mist.UnknownProvider(provider)) -> handle_unknown(provider)
+  Error(vestibule_mist.MissingSessionCookie) -> handle_missing_cookie()
+  Error(vestibule_mist.SessionExpired) -> handle_expired_session()
+  Error(vestibule_mist.InvalidCallbackParams) -> handle_bad_callback()
+  Error(vestibule_mist.AuthFailed(err)) -> handle_auth_failure(err)
+}
+```
+
+`callback_phase` renders a generic authentication failure page on error so
+provider-controlled error descriptions are not reflected to users. Use
+`callback_phase_auth_result` when the application needs structured error
+details for logging or custom rendering.
+
+Malformed provider responses and missing `state` or `code` parameters are
+reported through `AuthFailed`. `InvalidCallbackParams` is returned when
+callback parameters cannot be extracted from the request, such as malformed
+POST form data.
+
+## POST callbacks
+
+`GET` callbacks read query parameters. `POST` callbacks read
+`application/x-www-form-urlencoded` body parameters (up to 64 KiB) and
+merge them over query parameters, so body values take precedence. If a
+POST body cannot be read, decoded as UTF-8, or parsed as form data,
+callback handling returns `InvalidCallbackParams` instead of falling back
+to query parameters.
+
+## State store
+
+`vestibule_mist` uses the shared `vestibule/state_store` from core
+`vestibule`. The same store can be passed to `vestibule_wisp` and
+`vestibule_mist` simultaneously; a single ETS owner process is shared
+across all transports.
+
+See the `vestibule/state_store` API docs for `try_init`, `init_named`,
+`store`, `retrieve`, and TTL semantics.

--- a/packages/vestibule_mist/README.md
+++ b/packages/vestibule_mist/README.md
@@ -29,7 +29,7 @@ high-entropy value (e.g. 64+ random bytes) and load it from configuration or
 a secrets manager.
 
 If the secret changes, existing OAuth callbacks cannot read the signed
-session cookie and will return `MissingSessionCookie`.
+session cookie and will return `MissingOrInvalidSessionCookie`.
 
 ## What it does
 
@@ -92,12 +92,13 @@ let options =
 Defaults match `vestibule_wisp`: cookie name `vestibule_session`, TTL 600
 seconds. The cookie TTL and server-side state-store TTL share the same
 value. The cookie is set with `HttpOnly`, `SameSite=Lax`, `Path=/`, and
-`Secure` when the request was made over HTTPS.
+`Secure` by default. For local HTTP development only, set `secure_cookie:
+False` with record-update syntax.
 
 If the signed cookie is missing, invalid, or signed with a different
-secret, the structured API returns `MissingSessionCookie`. If the cookie is
-valid but the stored state is missing, expired, or already used, it returns
-`SessionExpired`.
+secret, the structured API returns `MissingOrInvalidSessionCookie`. If the
+cookie is valid but the stored state is missing, expired, or already used, it
+returns `SessionUnavailable`.
 
 ## Callback error handling
 
@@ -114,8 +115,8 @@ valid but the stored state is missing, expired, or already used, it returns
 case vestibule_mist.callback_phase_auth_result(req, reg, provider, store, options) {
   Ok(auth) -> on_success(auth)
   Error(vestibule_mist.UnknownProvider(provider)) -> handle_unknown(provider)
-  Error(vestibule_mist.MissingSessionCookie) -> handle_missing_cookie()
-  Error(vestibule_mist.SessionExpired) -> handle_expired_session()
+  Error(vestibule_mist.MissingOrInvalidSessionCookie) -> handle_missing_cookie()
+  Error(vestibule_mist.SessionUnavailable) -> handle_expired_session()
   Error(vestibule_mist.InvalidCallbackParams) -> handle_bad_callback()
   Error(vestibule_mist.AuthFailed(err)) -> handle_auth_failure(err)
 }

--- a/packages/vestibule_mist/gleam.toml
+++ b/packages/vestibule_mist/gleam.toml
@@ -1,0 +1,17 @@
+name = "vestibule_mist"
+version = "0.1.0"
+description = "Mist middleware for vestibule OAuth authentication"
+licences = ["MIT"]
+repository = { type = "github", user = "tylerbutler", repo = "vestibule", path = "packages/vestibule_mist" }
+gleam = ">= 1.7.0"
+
+[dependencies]
+vestibule = { path = "../.." }
+mist = ">= 6.0.0 and < 7.0.0"
+gleam_stdlib = ">= 0.48.0 and < 2.0.0"
+gleam_http = ">= 4.3.0 and < 5.0.0"
+gleam_crypto = ">= 1.5.0 and < 2.0.0"
+gleam_erlang = ">= 1.0.0 and < 2.0.0"
+
+[dev-dependencies]
+startest = ">= 0.8.0 and < 1.0.0"

--- a/packages/vestibule_mist/manifest.toml
+++ b/packages/vestibule_mist/manifest.toml
@@ -2,13 +2,13 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
   { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
-  { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
+  { name = "gleam_crypto", version = "1.5.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "43A25BCE17834475AEA7FFC9408B6D0FC1D709A682BCAE5FEFC6D4192CF47718" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_http", version = "4.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "82EA6A717C842456188C190AFB372665EA56CE13D8559BF3B1DD9E40F619EE0C" },
   { name = "gleam_httpc", version = "5.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gleam_httpc", source = "hex", outer_checksum = "C545172618D07811494E97AAA4A0FB34DA6F6D0061FDC8041C2F8E3BE2B2E48F" },
@@ -16,23 +16,28 @@ packages = [
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
-  { name = "gleam_stdlib", version = "0.68.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F7FAEBD8EF260664E86A46C8DBA23508D1D11BB3BCC6EE1B89B3BC3E5C83FF1E" },
+  { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glisten", version = "9.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "D92808C66F7D3F22F2289CD04CBA8151757AAE9CB3D86992F0C6DE32A41205E1" },
   { name = "glow_auth", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_json", "gleam_stdlib", "gleam_time"], otp_app = "glow_auth", source = "hex", outer_checksum = "BCF868EC62BA7431A38D267EF00CFD846E28C6EAA5B349CB3099EAC013C6C7CB" },
+  { name = "gramps", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "8B7195978FBFD30B43DF791A8A272041B81E45D245314D7A41FC57237AA882A0" },
+  { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
-  { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
+  { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
+  { name = "mist", version = "6.0.2", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "6B03DEEA38A02F276333CB27B53B16D3D45BD741B89599085A601BAF635F2006" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
-  { name = "tom", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "90791DA4AACE637E30081FE77049B8DB850FBC8CACC31515376BCC4E59BE1DD2" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
+  { name = "vestibule", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_http", "gleam_httpc", "gleam_json", "gleam_stdlib", "gleam_time", "glow_auth"], source = "local", path = "../.." },
 ]
 
 [requirements]
 gleam_crypto = { version = ">= 1.5.0 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
-gleam_httpc = { version = ">= 5.0.0 and < 6.0.0" }
-gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
-gleam_time = { version = ">= 1.7.0 and < 2.0.0" }
-glow_auth = { version = ">= 1.0.1 and < 2.0.0" }
+mist = { version = ">= 6.0.0 and < 7.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }
+vestibule = { path = "../.." }

--- a/packages/vestibule_mist/src/vestibule_mist.gleam
+++ b/packages/vestibule_mist/src/vestibule_mist.gleam
@@ -108,11 +108,8 @@ pub fn request_phase(
     )
   {
     Error(transport_flow.UnknownProvider(_)) -> not_found_response()
-    Error(transport_flow.AuthFailed(err)) -> error_response(err)
-    Error(transport_flow.StoreFailed(_)) ->
-      error_response(error.ConfigError(
-        reason: "Failed to store OAuth session state",
-      ))
+    Error(transport_flow.AuthFailed(_)) -> generic_error_response()
+    Error(transport_flow.StoreFailed(_)) -> generic_error_response()
     Ok(#(url, session_id)) -> {
       let token = signed_cookie.sign(session_id, options.secret_key_base)
       let attrs =
@@ -211,7 +208,7 @@ pub fn callback_phase_auth_result_with_params(
   store: StateStore,
   options: Options,
 ) -> Result(Auth, CallbackError(e)) {
-  use _ <- result.try(
+  use strategy_config <- result.try(
     transport_flow.ensure_callback_provider(reg, provider)
     |> result.map_error(map_callback_flow_error),
   )
@@ -222,7 +219,7 @@ pub fn callback_phase_auth_result_with_params(
     options.secret_key_base,
   ))
 
-  transport_flow.finish_callback(reg, provider, store, params, session_id)
+  transport_flow.finish_callback(strategy_config, store, params, session_id)
   |> result.map_error(map_callback_flow_error)
 }
 
@@ -284,15 +281,10 @@ fn map_callback_flow_error(
 fn callback_error_response(err: CallbackError(e)) -> Response(ResponseData) {
   case err {
     UnknownProvider(_) -> not_found_response()
-    MissingOrInvalidSessionCookie ->
-      error_response(error.ConfigError(reason: "Missing session cookie"))
-    SessionUnavailable ->
-      error_response(error.ConfigError(
-        reason: "Session expired or already used",
-      ))
-    InvalidCallbackParams ->
-      error_response(error.ConfigError(reason: "Invalid callback parameters"))
-    AuthFailed(err) -> error_response(err)
+    MissingOrInvalidSessionCookie -> generic_error_response()
+    SessionUnavailable -> generic_error_response()
+    InvalidCallbackParams -> generic_error_response()
+    AuthFailed(_) -> generic_error_response()
   }
 }
 
@@ -308,7 +300,7 @@ fn not_found_response() -> Response(ResponseData) {
   |> response.set_body(mist.Bytes(bytes_tree.from_string("Not Found")))
 }
 
-fn error_response(_err: error.AuthError(e)) -> Response(ResponseData) {
+fn generic_error_response() -> Response(ResponseData) {
   let body =
     "<html>
 <head><title>Authentication Error</title></head>

--- a/packages/vestibule_mist/src/vestibule_mist.gleam
+++ b/packages/vestibule_mist/src/vestibule_mist.gleam
@@ -1,0 +1,342 @@
+//// Mist middleware that wires a `Registry` of `Strategy` values into HTTP
+//// endpoints.
+////
+//// Provides `request_phase` (start an authorization flow, persist `state`
+//// and `code_verifier`) and `callback_phase` (validate state, exchange
+//// code, fetch user, invoke caller's success handler). Uses the shared
+//// `vestibule/state_store` for single-use storage of in-flight flow state
+//// and an HMAC-SHA256 signed cookie to bind a browser session to a stored
+//// state entry.
+////
+//// Unlike `vestibule_wisp`, mist has no built-in signed cookie helper, so
+//// the secret key base must be supplied via `new_options/1`. There is no
+//// `default_options` — callers must construct `Options` explicitly so the
+//// type system enforces a conscious secret choice.
+
+import gleam/bit_array
+import gleam/bytes_tree
+import gleam/dict
+import gleam/http
+import gleam/http/cookie
+import gleam/http/request.{type Request}
+import gleam/http/response.{type Response}
+import gleam/list
+import gleam/option
+import gleam/result
+import gleam/uri
+import mist.{type Connection, type ResponseData}
+
+import vestibule
+import vestibule/auth.{type Auth}
+import vestibule/authorization_request
+import vestibule/error
+import vestibule/registry.{type Registry}
+import vestibule/state
+import vestibule/state_store.{type StateStore}
+import vestibule_mist/signed_cookie
+
+/// Maximum body size accepted from a POST callback. 64 KiB is well above the
+/// largest realistic OAuth form_post payload (an Apple identity_token is a few
+/// KiB) and small enough to reject obvious abuse without risking truncation.
+const max_callback_body_bytes: Int = 65_536
+
+/// Middleware configuration options.
+///
+/// Construct with `new_options/1`. There is no `default_options` because the
+/// HMAC `secret_key_base` is mandatory and has no safe default.
+pub type Options {
+  Options(
+    secret_key_base: BitArray,
+    cookie_name: String,
+    session_ttl_seconds: Int,
+  )
+}
+
+/// Structured errors that can occur during the OAuth callback phase.
+pub type CallbackError(e) {
+  /// The requested provider is not registered.
+  UnknownProvider(provider: String)
+  /// The signed session cookie set during the request phase is missing or
+  /// invalid (no cookie present, signature mismatch, wrong secret, tampered
+  /// payload).
+  MissingSessionCookie
+  /// The session state was not found, expired, or already used.
+  SessionExpired
+  /// Callback parameters could not be extracted from the request (e.g.
+  /// malformed POST body, body too large, non-UTF-8 body).
+  InvalidCallbackParams
+  /// Provider authentication failed.
+  AuthFailed(error.AuthError(e))
+}
+
+/// Build middleware options with the given HMAC `secret_key_base`.
+///
+/// Defaults: cookie name `vestibule_session`, session TTL 600 seconds. Update
+/// fields directly to customize (`Options(..options, session_ttl_seconds: 300)`).
+pub fn new_options(secret_key_base: BitArray) -> Options {
+  Options(
+    secret_key_base: secret_key_base,
+    cookie_name: "vestibule_session",
+    session_ttl_seconds: 600,
+  )
+}
+
+/// Phase 1: Redirect the user to the OAuth provider.
+///
+/// Looks up the provider in the registry, generates an authorization URL with
+/// PKCE parameters, stores the CSRF state and code verifier in `store`, sets
+/// a signed session cookie, and returns a 302 response.
+///
+/// Returns 404 if the provider is not registered, or a generic 400 HTML error
+/// if URL generation or state persistence fails.
+///
+/// Generic over the request body type: the body is never read, only request
+/// metadata (scheme, cookies) is inspected.
+pub fn request_phase(
+  req: Request(body),
+  reg: Registry(e),
+  provider: String,
+  store: StateStore,
+  options: Options,
+) -> Response(ResponseData) {
+  case registry.get(reg, provider) {
+    Error(Nil) -> not_found_response()
+    Ok(#(strategy, config)) ->
+      case vestibule.authorize_url(strategy, config) {
+        Ok(auth_request) ->
+          case
+            state_store.try_store_with_ttl(
+              store,
+              authorization_request.state(auth_request),
+              authorization_request.code_verifier(auth_request),
+              options.session_ttl_seconds,
+            )
+          {
+            Ok(session_id) -> {
+              let token =
+                signed_cookie.sign(session_id, options.secret_key_base)
+              let attrs =
+                cookie.Attributes(
+                  max_age: option.Some(options.session_ttl_seconds),
+                  domain: option.None,
+                  path: option.Some("/"),
+                  secure: req.scheme == http.Https,
+                  http_only: True,
+                  same_site: option.Some(cookie.Lax),
+                )
+              redirect(authorization_request.url(auth_request))
+              |> response.set_cookie(options.cookie_name, token, attrs)
+            }
+            Error(_) ->
+              error_response(error.ConfigError(
+                reason: "Failed to store OAuth session state",
+              ))
+          }
+        Error(err) -> error_response(err)
+      }
+  }
+}
+
+/// Phase 2: Handle the OAuth callback and return the `Auth` result to the
+/// provided callback function.
+///
+/// Supports both GET callbacks (query parameters) and POST callbacks
+/// (form-encoded body), as required by providers like Apple that use
+/// `response_mode=form_post`. For POST requests, form body parameters take
+/// precedence over query parameters.
+///
+/// On success, calls `on_success` with the `Auth`. On error, returns a
+/// generic HTML error page. Returns 404 if the provider is not registered.
+pub fn callback_phase(
+  req: Request(Connection),
+  reg: Registry(e),
+  provider: String,
+  store: StateStore,
+  options: Options,
+  on_success: fn(Auth) -> Response(ResponseData),
+) -> Response(ResponseData) {
+  case callback_phase_auth_result(req, reg, provider, store, options) {
+    Ok(auth) -> on_success(auth)
+    Error(err) -> callback_error_response(err)
+  }
+}
+
+/// Phase 2 (Result variant): Handle the OAuth callback and return either the
+/// `Auth` result or an error `Response`.
+///
+/// Use this instead of `callback_phase` when you want to decide how to use the
+/// success value or generated error response yourself.
+pub fn callback_phase_result(
+  req: Request(Connection),
+  reg: Registry(e),
+  provider: String,
+  store: StateStore,
+  options: Options,
+) -> Result(Auth, Response(ResponseData)) {
+  callback_phase_auth_result(req, reg, provider, store, options)
+  |> result.map_error(callback_error_response)
+}
+
+/// Phase 2 (structured Result variant): Handle the OAuth callback and return
+/// either the `Auth` result or a structured `CallbackError`.
+///
+/// Use this when you want to distinguish provider lookup, session, callback
+/// parameter, and provider authentication failures without parsing responses.
+///
+/// Callback parameters are parsed and state is validated before the stored
+/// session is consumed, so malformed or wrong-state callbacks do not burn a
+/// valid in-flight login.
+pub fn callback_phase_auth_result(
+  req: Request(Connection),
+  reg: Registry(e),
+  provider: String,
+  store: StateStore,
+  options: Options,
+) -> Result(Auth, CallbackError(e)) {
+  use params <- result.try(get_callback_params(req))
+  callback_phase_auth_result_with_params(req, params, reg, provider, store, options)
+}
+
+/// Phase 2 with pre-extracted callback parameters.
+///
+/// Useful when the caller has already read the request body (or otherwise
+/// resolved the form/query parameters) and wants to hand them in directly.
+/// Generic over the request body type so it can be used in unit tests with
+/// `Request(BitArray)` or any other body.
+pub fn callback_phase_auth_result_with_params(
+  req: Request(body),
+  params: dict.Dict(String, String),
+  reg: Registry(e),
+  provider: String,
+  store: StateStore,
+  options: Options,
+) -> Result(Auth, CallbackError(e)) {
+  use #(strategy, config) <- result.try(
+    registry.get(reg, provider)
+    |> result.map_error(fn(_) { UnknownProvider(provider) }),
+  )
+
+  use received_state <- result.try(
+    dict.get(params, "state")
+    |> result.replace_error(AuthFailed(error.MissingCallbackParam("state"))),
+  )
+
+  use session_id <- result.try(get_signed_cookie(
+    req,
+    options.cookie_name,
+    options.secret_key_base,
+  ))
+
+  use #(expected_state, _code_verifier) <- result.try(
+    state_store.peek(store, session_id)
+    |> result.map_error(fn(_) { SessionExpired }),
+  )
+
+  use _ <- result.try(
+    state.validate(received_state, expected_state)
+    |> result.map_error(AuthFailed),
+  )
+
+  use #(expected_state, code_verifier) <- result.try(
+    state_store.retrieve(store, session_id)
+    |> result.map_error(fn(_) { SessionExpired }),
+  )
+
+  vestibule.handle_callback(
+    strategy,
+    config,
+    params,
+    expected_state,
+    code_verifier,
+  )
+  |> result.map_error(AuthFailed)
+}
+
+fn get_signed_cookie(
+  req: Request(body),
+  cookie_name: String,
+  secret_key_base: BitArray,
+) -> Result(String, CallbackError(e)) {
+  let cookies = request.get_cookies(req)
+  case list.key_find(cookies, cookie_name) {
+    Error(Nil) -> Error(MissingSessionCookie)
+    Ok(token) ->
+      signed_cookie.verify(token, secret_key_base)
+      |> result.map_error(fn(_) { MissingSessionCookie })
+  }
+}
+
+/// Extract callback parameters from either query string (GET) or
+/// form-encoded body (POST). For POST requests, body parameters are merged
+/// over query parameters so body values take precedence.
+fn get_callback_params(
+  req: Request(Connection),
+) -> Result(dict.Dict(String, String), CallbackError(e)) {
+  let query_params = case req.query {
+    option.Some(q) -> uri.parse_query(q) |> result.unwrap([])
+    option.None -> []
+  }
+  case req.method {
+    http.Post -> {
+      case mist.read_body(req, max_callback_body_bytes) {
+        Ok(req_with_body) ->
+          case bit_array.to_string(req_with_body.body) {
+            Ok(body_string) ->
+              case uri.parse_query(body_string) {
+                Ok(body_params) ->
+                  Ok(dict.merge(
+                    dict.from_list(query_params),
+                    dict.from_list(body_params),
+                  ))
+                Error(_) -> Error(InvalidCallbackParams)
+              }
+            Error(_) -> Error(InvalidCallbackParams)
+          }
+        Error(_) -> Error(InvalidCallbackParams)
+      }
+    }
+    _ -> Ok(dict.from_list(query_params))
+  }
+}
+
+fn callback_error_response(err: CallbackError(e)) -> Response(ResponseData) {
+  case err {
+    UnknownProvider(_) -> not_found_response()
+    MissingSessionCookie ->
+      error_response(error.ConfigError(reason: "Missing session cookie"))
+    SessionExpired ->
+      error_response(error.ConfigError(
+        reason: "Session expired or already used",
+      ))
+    InvalidCallbackParams ->
+      error_response(error.ConfigError(reason: "Invalid callback parameters"))
+    AuthFailed(err) -> error_response(err)
+  }
+}
+
+fn redirect(location: String) -> Response(ResponseData) {
+  response.new(302)
+  |> response.set_header("location", location)
+  |> response.set_body(mist.Bytes(bytes_tree.new()))
+}
+
+fn not_found_response() -> Response(ResponseData) {
+  response.new(404)
+  |> response.set_header("content-type", "text/plain; charset=utf-8")
+  |> response.set_body(mist.Bytes(bytes_tree.from_string("Not Found")))
+}
+
+fn error_response(_err: error.AuthError(e)) -> Response(ResponseData) {
+  let body =
+    "<html>
+<head><title>Authentication Error</title></head>
+<body style=\"font-family: system-ui, sans-serif; max-width: 600px; margin: 80px auto;\">
+  <h1>Authentication Failed</h1>
+  <p style=\"color: #c0392b;\">Authentication failed. Please try again.</p>
+  <a href=\"/\">Try again</a>
+</body>
+</html>"
+  response.new(400)
+  |> response.set_header("content-type", "text/html; charset=utf-8")
+  |> response.set_body(mist.Bytes(bytes_tree.from_string(body)))
+}

--- a/packages/vestibule_mist/src/vestibule_mist.gleam
+++ b/packages/vestibule_mist/src/vestibule_mist.gleam
@@ -26,13 +26,11 @@ import gleam/result
 import gleam/uri
 import mist.{type Connection, type ResponseData}
 
-import vestibule
 import vestibule/auth.{type Auth}
-import vestibule/authorization_request
 import vestibule/error
 import vestibule/registry.{type Registry}
-import vestibule/state
 import vestibule/state_store.{type StateStore}
+import vestibule/transport_flow
 import vestibule_mist/signed_cookie
 
 /// Maximum body size accepted from a POST callback. 64 KiB is well above the
@@ -49,6 +47,7 @@ pub type Options {
     secret_key_base: BitArray,
     cookie_name: String,
     session_ttl_seconds: Int,
+    secure_cookie: Bool,
   )
 }
 
@@ -59,9 +58,9 @@ pub type CallbackError(e) {
   /// The signed session cookie set during the request phase is missing or
   /// invalid (no cookie present, signature mismatch, wrong secret, tampered
   /// payload).
-  MissingSessionCookie
+  MissingOrInvalidSessionCookie
   /// The session state was not found, expired, or already used.
-  SessionExpired
+  SessionUnavailable
   /// Callback parameters could not be extracted from the request (e.g.
   /// malformed POST body, body too large, non-UTF-8 body).
   InvalidCallbackParams
@@ -78,6 +77,7 @@ pub fn new_options(secret_key_base: BitArray) -> Options {
     secret_key_base: secret_key_base,
     cookie_name: "vestibule_session",
     session_ttl_seconds: 600,
+    secure_cookie: True,
   )
 }
 
@@ -93,47 +93,40 @@ pub fn new_options(secret_key_base: BitArray) -> Options {
 /// Generic over the request body type: the body is never read, only request
 /// metadata (scheme, cookies) is inspected.
 pub fn request_phase(
-  req: Request(body),
+  _req: Request(body),
   reg: Registry(e),
   provider: String,
   store: StateStore,
   options: Options,
 ) -> Response(ResponseData) {
-  case registry.get(reg, provider) {
-    Error(Nil) -> not_found_response()
-    Ok(#(strategy, config)) ->
-      case vestibule.authorize_url(strategy, config) {
-        Ok(auth_request) ->
-          case
-            state_store.try_store_with_ttl(
-              store,
-              authorization_request.state(auth_request),
-              authorization_request.code_verifier(auth_request),
-              options.session_ttl_seconds,
-            )
-          {
-            Ok(session_id) -> {
-              let token =
-                signed_cookie.sign(session_id, options.secret_key_base)
-              let attrs =
-                cookie.Attributes(
-                  max_age: option.Some(options.session_ttl_seconds),
-                  domain: option.None,
-                  path: option.Some("/"),
-                  secure: req.scheme == http.Https,
-                  http_only: True,
-                  same_site: option.Some(cookie.Lax),
-                )
-              redirect(authorization_request.url(auth_request))
-              |> response.set_cookie(options.cookie_name, token, attrs)
-            }
-            Error(_) ->
-              error_response(error.ConfigError(
-                reason: "Failed to store OAuth session state",
-              ))
-          }
-        Error(err) -> error_response(err)
-      }
+  case
+    transport_flow.start_authorization(
+      reg,
+      provider,
+      store,
+      options.session_ttl_seconds,
+    )
+  {
+    Error(transport_flow.UnknownProvider(_)) -> not_found_response()
+    Error(transport_flow.AuthFailed(err)) -> error_response(err)
+    Error(transport_flow.StoreFailed(_)) ->
+      error_response(error.ConfigError(
+        reason: "Failed to store OAuth session state",
+      ))
+    Ok(#(url, session_id)) -> {
+      let token = signed_cookie.sign(session_id, options.secret_key_base)
+      let attrs =
+        cookie.Attributes(
+          max_age: option.Some(options.session_ttl_seconds),
+          domain: option.None,
+          path: option.Some("/"),
+          secure: options.secure_cookie,
+          http_only: True,
+          same_site: option.Some(cookie.Lax),
+        )
+      redirect(url)
+      |> response.set_cookie(options.cookie_name, token, attrs)
+    }
   }
 }
 
@@ -194,7 +187,14 @@ pub fn callback_phase_auth_result(
   options: Options,
 ) -> Result(Auth, CallbackError(e)) {
   use params <- result.try(get_callback_params(req))
-  callback_phase_auth_result_with_params(req, params, reg, provider, store, options)
+  callback_phase_auth_result_with_params(
+    req,
+    params,
+    reg,
+    provider,
+    store,
+    options,
+  )
 }
 
 /// Phase 2 with pre-extracted callback parameters.
@@ -211,14 +211,9 @@ pub fn callback_phase_auth_result_with_params(
   store: StateStore,
   options: Options,
 ) -> Result(Auth, CallbackError(e)) {
-  use #(strategy, config) <- result.try(
-    registry.get(reg, provider)
-    |> result.map_error(fn(_) { UnknownProvider(provider) }),
-  )
-
-  use received_state <- result.try(
-    dict.get(params, "state")
-    |> result.replace_error(AuthFailed(error.MissingCallbackParam("state"))),
+  use _ <- result.try(
+    transport_flow.ensure_callback_provider(reg, provider)
+    |> result.map_error(map_callback_flow_error),
   )
 
   use session_id <- result.try(get_signed_cookie(
@@ -227,29 +222,8 @@ pub fn callback_phase_auth_result_with_params(
     options.secret_key_base,
   ))
 
-  use #(expected_state, _code_verifier) <- result.try(
-    state_store.peek(store, session_id)
-    |> result.map_error(fn(_) { SessionExpired }),
-  )
-
-  use _ <- result.try(
-    state.validate(received_state, expected_state)
-    |> result.map_error(AuthFailed),
-  )
-
-  use #(expected_state, code_verifier) <- result.try(
-    state_store.retrieve(store, session_id)
-    |> result.map_error(fn(_) { SessionExpired }),
-  )
-
-  vestibule.handle_callback(
-    strategy,
-    config,
-    params,
-    expected_state,
-    code_verifier,
-  )
-  |> result.map_error(AuthFailed)
+  transport_flow.finish_callback(reg, provider, store, params, session_id)
+  |> result.map_error(map_callback_flow_error)
 }
 
 fn get_signed_cookie(
@@ -259,10 +233,10 @@ fn get_signed_cookie(
 ) -> Result(String, CallbackError(e)) {
   let cookies = request.get_cookies(req)
   case list.key_find(cookies, cookie_name) {
-    Error(Nil) -> Error(MissingSessionCookie)
+    Error(Nil) -> Error(MissingOrInvalidSessionCookie)
     Ok(token) ->
       signed_cookie.verify(token, secret_key_base)
-      |> result.map_error(fn(_) { MissingSessionCookie })
+      |> result.map_error(fn(_) { MissingOrInvalidSessionCookie })
   }
 }
 
@@ -278,33 +252,41 @@ fn get_callback_params(
   }
   case req.method {
     http.Post -> {
-      case mist.read_body(req, max_callback_body_bytes) {
-        Ok(req_with_body) ->
-          case bit_array.to_string(req_with_body.body) {
-            Ok(body_string) ->
-              case uri.parse_query(body_string) {
-                Ok(body_params) ->
-                  Ok(dict.merge(
-                    dict.from_list(query_params),
-                    dict.from_list(body_params),
-                  ))
-                Error(_) -> Error(InvalidCallbackParams)
-              }
-            Error(_) -> Error(InvalidCallbackParams)
-          }
-        Error(_) -> Error(InvalidCallbackParams)
-      }
+      use req_with_body <- result.try(
+        mist.read_body(req, max_callback_body_bytes)
+        |> result.map_error(fn(_) { InvalidCallbackParams }),
+      )
+      use body_string <- result.try(
+        bit_array.to_string(req_with_body.body)
+        |> result.map_error(fn(_) { InvalidCallbackParams }),
+      )
+      use body_params <- result.try(
+        uri.parse_query(body_string)
+        |> result.map_error(fn(_) { InvalidCallbackParams }),
+      )
+      Ok(dict.merge(dict.from_list(query_params), dict.from_list(body_params)))
     }
     _ -> Ok(dict.from_list(query_params))
+  }
+}
+
+fn map_callback_flow_error(
+  err: transport_flow.CallbackFlowError(e),
+) -> CallbackError(e) {
+  case err {
+    transport_flow.CallbackUnknownProvider(provider) ->
+      UnknownProvider(provider)
+    transport_flow.CallbackSessionUnavailable -> SessionUnavailable
+    transport_flow.CallbackAuthFailed(err) -> AuthFailed(err)
   }
 }
 
 fn callback_error_response(err: CallbackError(e)) -> Response(ResponseData) {
   case err {
     UnknownProvider(_) -> not_found_response()
-    MissingSessionCookie ->
+    MissingOrInvalidSessionCookie ->
       error_response(error.ConfigError(reason: "Missing session cookie"))
-    SessionExpired ->
+    SessionUnavailable ->
       error_response(error.ConfigError(
         reason: "Session expired or already used",
       ))

--- a/packages/vestibule_mist/src/vestibule_mist/signed_cookie.gleam
+++ b/packages/vestibule_mist/src/vestibule_mist/signed_cookie.gleam
@@ -6,6 +6,7 @@
 
 import gleam/bit_array
 import gleam/crypto
+import gleam/result
 
 /// Sign `payload` with `secret_key_base` using HMAC-SHA256 and return a
 /// URL-safe token (`protected.payload.signature`) suitable for use as a
@@ -22,8 +23,9 @@ pub fn sign(payload: String, secret_key_base: BitArray) -> String {
 /// payload string, or `Error(Nil)` if the token is malformed, the
 /// signature does not match, or the payload is not valid UTF-8.
 pub fn verify(token: String, secret_key_base: BitArray) -> Result(String, Nil) {
-  case crypto.verify_signed_message(token, secret_key_base) {
-    Ok(payload_bits) -> bit_array.to_string(payload_bits)
-    Error(Nil) -> Error(Nil)
-  }
+  use payload_bits <- result.try(crypto.verify_signed_message(
+    token,
+    secret_key_base,
+  ))
+  bit_array.to_string(payload_bits)
 }

--- a/packages/vestibule_mist/src/vestibule_mist/signed_cookie.gleam
+++ b/packages/vestibule_mist/src/vestibule_mist/signed_cookie.gleam
@@ -1,0 +1,29 @@
+//// HMAC-SHA256 signed cookie payload helpers.
+////
+//// Thin wrapper over `gleam_crypto`'s `sign_message`/`verify_signed_message`
+//// to standardize the signing algorithm and produce a String token suitable
+//// for use as a cookie value.
+
+import gleam/bit_array
+import gleam/crypto
+
+/// Sign `payload` with `secret_key_base` using HMAC-SHA256 and return a
+/// URL-safe token (`protected.payload.signature`) suitable for use as a
+/// cookie value.
+pub fn sign(payload: String, secret_key_base: BitArray) -> String {
+  crypto.sign_message(
+    bit_array.from_string(payload),
+    secret_key_base,
+    crypto.Sha256,
+  )
+}
+
+/// Verify a token previously produced by `sign/2`. Returns the original
+/// payload string, or `Error(Nil)` if the token is malformed, the
+/// signature does not match, or the payload is not valid UTF-8.
+pub fn verify(token: String, secret_key_base: BitArray) -> Result(String, Nil) {
+  case crypto.verify_signed_message(token, secret_key_base) {
+    Ok(payload_bits) -> bit_array.to_string(payload_bits)
+    Error(Nil) -> Error(Nil)
+  }
+}

--- a/packages/vestibule_mist/test/vestibule_mist_test.gleam
+++ b/packages/vestibule_mist/test/vestibule_mist_test.gleam
@@ -1,6 +1,6 @@
 import gleam/dict
-import gleam/http
 import gleam/http/request
+import gleam/list
 import gleam/option
 import gleam/string
 import startest
@@ -56,6 +56,7 @@ pub fn new_options_uses_default_cookie_contract_test() {
     secret_key_base: secret,
     cookie_name: "vestibule_session",
     session_ttl_seconds: 600,
+    secure_cookie: True,
   ))
 }
 
@@ -95,23 +96,23 @@ pub fn request_phase_success_sets_signed_cookie_and_redirects_test() {
   { string.contains(cookie_header, "HttpOnly") } |> expect.to_be_true()
   { string.contains(cookie_header, "SameSite=Lax") } |> expect.to_be_true()
   { string.contains(cookie_header, "Path=/") } |> expect.to_be_true()
+  { string.contains(cookie_header, "Secure") } |> expect.to_be_true()
 }
 
-pub fn request_phase_https_request_marks_cookie_secure_test() {
+pub fn request_phase_allows_secure_cookie_opt_out_test() {
   let req =
     request.new()
-    |> request.set_scheme(http.Https)
     |> request.set_path("/auth/test")
-  let store = state_store.init_named("test_mist_request_https_secure_cookie")
+  let store = state_store.init_named("test_mist_request_secure_cookie_opt_out")
   let reg =
     registry.new()
     |> registry.register(test_strategy(), test_config())
+  let options = vestibule_mist.Options(..test_options(), secure_cookie: False)
 
-  let resp =
-    vestibule_mist.request_phase(req, reg, "test", store, test_options())
+  let resp = vestibule_mist.request_phase(req, reg, "test", store, options)
 
   let assert Ok(cookie_header) = find_header(resp.headers, "set-cookie")
-  { string.contains(cookie_header, "Secure") } |> expect.to_be_true()
+  { string.contains(cookie_header, "Secure") } |> expect.to_be_false()
 }
 
 // === callback_phase_auth_result_with_params ===
@@ -146,7 +147,7 @@ pub fn callback_missing_session_cookie_test() {
     store,
     test_options(),
   )
-  |> expect.to_equal(Error(vestibule_mist.MissingSessionCookie))
+  |> expect.to_equal(Error(vestibule_mist.MissingOrInvalidSessionCookie))
 }
 
 pub fn callback_tampered_cookie_fails_as_missing_test() {
@@ -166,7 +167,7 @@ pub fn callback_tampered_cookie_fails_as_missing_test() {
     store,
     test_options(),
   )
-  |> expect.to_equal(Error(vestibule_mist.MissingSessionCookie))
+  |> expect.to_equal(Error(vestibule_mist.MissingOrInvalidSessionCookie))
 }
 
 pub fn callback_wrong_secret_fails_as_missing_test() {
@@ -189,7 +190,7 @@ pub fn callback_wrong_secret_fails_as_missing_test() {
     store,
     test_options(),
   )
-  |> expect.to_equal(Error(vestibule_mist.MissingSessionCookie))
+  |> expect.to_equal(Error(vestibule_mist.MissingOrInvalidSessionCookie))
 }
 
 pub fn callback_missing_state_does_not_consume_session_test() {
@@ -246,7 +247,7 @@ pub fn callback_unknown_session_returns_expired_test() {
     store,
     test_options(),
   )
-  |> expect.to_equal(Error(vestibule_mist.SessionExpired))
+  |> expect.to_equal(Error(vestibule_mist.SessionUnavailable))
 }
 
 pub fn callback_auth_result_preserves_provider_error_details_test() {
@@ -298,7 +299,7 @@ pub fn callback_custom_cookie_name_is_honored_test() {
     store,
     test_options(),
   )
-  |> expect.to_equal(Error(vestibule_mist.MissingSessionCookie))
+  |> expect.to_equal(Error(vestibule_mist.MissingOrInvalidSessionCookie))
 
   let custom_options =
     vestibule_mist.Options(..test_options(), cookie_name: "custom_session")
@@ -372,12 +373,5 @@ fn find_header(
   headers: List(#(String, String)),
   name: String,
 ) -> Result(String, Nil) {
-  case headers {
-    [] -> Error(Nil)
-    [#(k, v), ..rest] ->
-      case k == name {
-        True -> Ok(v)
-        False -> find_header(rest, name)
-      }
-  }
+  list.key_find(headers, name)
 }

--- a/packages/vestibule_mist/test/vestibule_mist_test.gleam
+++ b/packages/vestibule_mist/test/vestibule_mist_test.gleam
@@ -81,7 +81,7 @@ pub fn request_phase_unknown_provider_returns_404_test() {
 pub fn request_phase_success_sets_signed_cookie_and_redirects_test() {
   let req = request.new() |> request.set_path("/auth/test")
   let store = state_store.init_named("test_mist_request_success")
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(test_strategy(), test_config())
 
@@ -104,7 +104,7 @@ pub fn request_phase_allows_secure_cookie_opt_out_test() {
     request.new()
     |> request.set_path("/auth/test")
   let store = state_store.init_named("test_mist_request_secure_cookie_opt_out")
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(test_strategy(), test_config())
   let options = vestibule_mist.Options(..test_options(), secure_cookie: False)
@@ -135,7 +135,7 @@ pub fn callback_unknown_provider_test() {
 pub fn callback_missing_session_cookie_test() {
   let req = request.new()
   let store = state_store.init_named("test_mist_cb_missing_cookie")
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(test_strategy(), test_config())
 
@@ -155,7 +155,7 @@ pub fn callback_tampered_cookie_fails_as_missing_test() {
     request.new()
     |> request.set_cookie("vestibule_session", "not-a-valid-signed-token")
   let store = state_store.init_named("test_mist_cb_tampered_cookie")
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(test_strategy(), test_config())
 
@@ -178,7 +178,7 @@ pub fn callback_wrong_secret_fails_as_missing_test() {
   let req =
     request.new()
     |> request.set_cookie("vestibule_session", token)
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(test_strategy(), test_config())
 
@@ -200,7 +200,7 @@ pub fn callback_missing_state_does_not_consume_session_test() {
   let req =
     request.new()
     |> request.set_cookie("vestibule_session", token)
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(test_strategy(), test_config())
 
@@ -235,7 +235,7 @@ pub fn callback_unknown_session_returns_expired_test() {
   let req =
     request.new()
     |> request.set_cookie("vestibule_session", token)
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(test_strategy(), test_config())
 
@@ -257,7 +257,7 @@ pub fn callback_auth_result_preserves_provider_error_details_test() {
   let req =
     request.new()
     |> request.set_cookie("vestibule_session", token)
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(leaky_error_strategy(), test_config())
 
@@ -287,7 +287,7 @@ pub fn callback_custom_cookie_name_is_honored_test() {
   let req =
     request.new()
     |> request.set_cookie("custom_session", token)
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(test_strategy(), test_config())
 

--- a/packages/vestibule_mist/test/vestibule_mist_test.gleam
+++ b/packages/vestibule_mist/test/vestibule_mist_test.gleam
@@ -1,0 +1,383 @@
+import gleam/dict
+import gleam/http
+import gleam/http/request
+import gleam/option
+import gleam/string
+import startest
+import startest/expect
+import vestibule/config
+import vestibule/error
+import vestibule/registry
+import vestibule/state_store
+import vestibule/strategy.{type Strategy}
+import vestibule_mist
+import vestibule_mist/signed_cookie
+
+pub fn main() -> Nil {
+  startest.run(startest.default_config())
+}
+
+// === signed_cookie ===
+
+pub fn signed_cookie_round_trip_test() {
+  let secret = test_secret()
+  let token = signed_cookie.sign("session-id-123", secret)
+  signed_cookie.verify(token, secret)
+  |> expect.to_be_ok()
+  |> expect.to_equal("session-id-123")
+}
+
+pub fn signed_cookie_verify_with_wrong_secret_fails_test() {
+  let secret = test_secret()
+  let other = <<"different-key-also-32-bytes-long":utf8>>
+  let token = signed_cookie.sign("session-id-123", secret)
+  signed_cookie.verify(token, other)
+  |> expect.to_be_error()
+}
+
+pub fn signed_cookie_verify_with_tampered_token_fails_test() {
+  let secret = test_secret()
+  let token = signed_cookie.sign("session-id-123", secret)
+  signed_cookie.verify(token <> "x", secret)
+  |> expect.to_be_error()
+}
+
+pub fn signed_cookie_verify_malformed_token_fails_test() {
+  signed_cookie.verify("not-a-valid-token", test_secret())
+  |> expect.to_be_error()
+}
+
+// === new_options ===
+
+pub fn new_options_uses_default_cookie_contract_test() {
+  let secret = test_secret()
+  vestibule_mist.new_options(secret)
+  |> expect.to_equal(vestibule_mist.Options(
+    secret_key_base: secret,
+    cookie_name: "vestibule_session",
+    session_ttl_seconds: 600,
+  ))
+}
+
+// === request_phase ===
+
+pub fn request_phase_unknown_provider_returns_404_test() {
+  let req = request.new() |> request.set_path("/auth/unknown")
+  let store = state_store.init_named("test_mist_request_unknown_provider")
+
+  let resp =
+    vestibule_mist.request_phase(
+      req,
+      registry.new(),
+      "unknown",
+      store,
+      test_options(),
+    )
+
+  resp.status |> expect.to_equal(404)
+}
+
+pub fn request_phase_success_sets_signed_cookie_and_redirects_test() {
+  let req = request.new() |> request.set_path("/auth/test")
+  let store = state_store.init_named("test_mist_request_success")
+  let reg =
+    registry.new()
+    |> registry.register(test_strategy(), test_config())
+
+  let resp =
+    vestibule_mist.request_phase(req, reg, "test", store, test_options())
+
+  resp.status |> expect.to_equal(302)
+  let assert Ok(_location) = find_header(resp.headers, "location")
+  let assert Ok(cookie_header) = find_header(resp.headers, "set-cookie")
+  { string.contains(cookie_header, "vestibule_session=") }
+  |> expect.to_be_true()
+  { string.contains(cookie_header, "HttpOnly") } |> expect.to_be_true()
+  { string.contains(cookie_header, "SameSite=Lax") } |> expect.to_be_true()
+  { string.contains(cookie_header, "Path=/") } |> expect.to_be_true()
+}
+
+pub fn request_phase_https_request_marks_cookie_secure_test() {
+  let req =
+    request.new()
+    |> request.set_scheme(http.Https)
+    |> request.set_path("/auth/test")
+  let store = state_store.init_named("test_mist_request_https_secure_cookie")
+  let reg =
+    registry.new()
+    |> registry.register(test_strategy(), test_config())
+
+  let resp =
+    vestibule_mist.request_phase(req, reg, "test", store, test_options())
+
+  let assert Ok(cookie_header) = find_header(resp.headers, "set-cookie")
+  { string.contains(cookie_header, "Secure") } |> expect.to_be_true()
+}
+
+// === callback_phase_auth_result_with_params ===
+
+pub fn callback_unknown_provider_test() {
+  let req = request.new()
+  let store = state_store.init_named("test_mist_cb_unknown_provider")
+
+  vestibule_mist.callback_phase_auth_result_with_params(
+    req,
+    dict.from_list([#("state", "s"), #("code", "c")]),
+    registry.new(),
+    "unknown",
+    store,
+    test_options(),
+  )
+  |> expect.to_equal(Error(vestibule_mist.UnknownProvider("unknown")))
+}
+
+pub fn callback_missing_session_cookie_test() {
+  let req = request.new()
+  let store = state_store.init_named("test_mist_cb_missing_cookie")
+  let reg =
+    registry.new()
+    |> registry.register(test_strategy(), test_config())
+
+  vestibule_mist.callback_phase_auth_result_with_params(
+    req,
+    dict.from_list([#("state", "s"), #("code", "c")]),
+    reg,
+    "test",
+    store,
+    test_options(),
+  )
+  |> expect.to_equal(Error(vestibule_mist.MissingSessionCookie))
+}
+
+pub fn callback_tampered_cookie_fails_as_missing_test() {
+  let req =
+    request.new()
+    |> request.set_cookie("vestibule_session", "not-a-valid-signed-token")
+  let store = state_store.init_named("test_mist_cb_tampered_cookie")
+  let reg =
+    registry.new()
+    |> registry.register(test_strategy(), test_config())
+
+  vestibule_mist.callback_phase_auth_result_with_params(
+    req,
+    dict.from_list([#("state", "s"), #("code", "c")]),
+    reg,
+    "test",
+    store,
+    test_options(),
+  )
+  |> expect.to_equal(Error(vestibule_mist.MissingSessionCookie))
+}
+
+pub fn callback_wrong_secret_fails_as_missing_test() {
+  let store = state_store.init_named("test_mist_cb_wrong_secret")
+  let session_id = state_store.store(store, "state", "verifier")
+  let other_secret = <<"some-other-secret-key-base!!!!!!":utf8>>
+  let token = signed_cookie.sign(session_id, other_secret)
+  let req =
+    request.new()
+    |> request.set_cookie("vestibule_session", token)
+  let reg =
+    registry.new()
+    |> registry.register(test_strategy(), test_config())
+
+  vestibule_mist.callback_phase_auth_result_with_params(
+    req,
+    dict.from_list([#("state", "state"), #("code", "c")]),
+    reg,
+    "test",
+    store,
+    test_options(),
+  )
+  |> expect.to_equal(Error(vestibule_mist.MissingSessionCookie))
+}
+
+pub fn callback_missing_state_does_not_consume_session_test() {
+  let store = state_store.init_named("test_mist_cb_missing_state_reusable")
+  let session_id = state_store.store(store, "state", "verifier")
+  let token = signed_cookie.sign(session_id, test_secret())
+  let req =
+    request.new()
+    |> request.set_cookie("vestibule_session", token)
+  let reg =
+    registry.new()
+    |> registry.register(test_strategy(), test_config())
+
+  vestibule_mist.callback_phase_auth_result_with_params(
+    req,
+    dict.from_list([#("code", "c")]),
+    reg,
+    "test",
+    store,
+    test_options(),
+  )
+  |> expect.to_equal(
+    Error(vestibule_mist.AuthFailed(error.MissingCallbackParam("state"))),
+  )
+
+  vestibule_mist.callback_phase_auth_result_with_params(
+    req,
+    dict.from_list([#("state", "state"), #("code", "c")]),
+    reg,
+    "test",
+    store,
+    test_options(),
+  )
+  |> expect.to_equal(
+    Error(vestibule_mist.AuthFailed(error.ConfigError(reason: "test"))),
+  )
+}
+
+pub fn callback_unknown_session_returns_expired_test() {
+  let store = state_store.init_named("test_mist_cb_unknown_session")
+  let token = signed_cookie.sign("nonexistent-session", test_secret())
+  let req =
+    request.new()
+    |> request.set_cookie("vestibule_session", token)
+  let reg =
+    registry.new()
+    |> registry.register(test_strategy(), test_config())
+
+  vestibule_mist.callback_phase_auth_result_with_params(
+    req,
+    dict.from_list([#("state", "s"), #("code", "c")]),
+    reg,
+    "test",
+    store,
+    test_options(),
+  )
+  |> expect.to_equal(Error(vestibule_mist.SessionExpired))
+}
+
+pub fn callback_auth_result_preserves_provider_error_details_test() {
+  let store = state_store.init_named("test_mist_cb_structured_error_details")
+  let session_id = state_store.store(store, "state", "verifier")
+  let token = signed_cookie.sign(session_id, test_secret())
+  let req =
+    request.new()
+    |> request.set_cookie("vestibule_session", token)
+  let reg =
+    registry.new()
+    |> registry.register(leaky_error_strategy(), test_config())
+
+  vestibule_mist.callback_phase_auth_result_with_params(
+    req,
+    dict.from_list([#("state", "state"), #("code", "c")]),
+    reg,
+    "test",
+    store,
+    test_options(),
+  )
+  |> expect.to_equal(
+    Error(
+      vestibule_mist.AuthFailed(error.ProviderError(
+        code: "invalid_request",
+        description: "provider-controlled phishing text secret-token",
+        uri: option.None,
+      )),
+    ),
+  )
+}
+
+pub fn callback_custom_cookie_name_is_honored_test() {
+  let store = state_store.init_named("test_mist_cb_custom_cookie_name")
+  let session_id = state_store.store(store, "state", "verifier")
+  let token = signed_cookie.sign(session_id, test_secret())
+  let req =
+    request.new()
+    |> request.set_cookie("custom_session", token)
+  let reg =
+    registry.new()
+    |> registry.register(test_strategy(), test_config())
+
+  vestibule_mist.callback_phase_auth_result_with_params(
+    req,
+    dict.from_list([#("state", "state"), #("code", "c")]),
+    reg,
+    "test",
+    store,
+    test_options(),
+  )
+  |> expect.to_equal(Error(vestibule_mist.MissingSessionCookie))
+
+  let custom_options =
+    vestibule_mist.Options(..test_options(), cookie_name: "custom_session")
+
+  vestibule_mist.callback_phase_auth_result_with_params(
+    req,
+    dict.from_list([#("state", "state"), #("code", "c")]),
+    reg,
+    "test",
+    store,
+    custom_options,
+  )
+  |> expect.to_equal(
+    Error(vestibule_mist.AuthFailed(error.ConfigError(reason: "test"))),
+  )
+}
+
+// === helpers ===
+
+fn test_secret() -> BitArray {
+  <<"vestibule_mist_test_secret_key_base!!":utf8>>
+}
+
+fn test_options() -> vestibule_mist.Options {
+  vestibule_mist.new_options(test_secret())
+}
+
+fn test_strategy() -> Strategy(e) {
+  strategy.new(
+    provider: "test",
+    default_scopes: [],
+    authorize_url: fn(_config, _scopes, _state) { Ok("https://example.com") },
+    exchange_code: fn(_config, _code, _code_verifier) {
+      Error(error.ConfigError(reason: "test"))
+    },
+    refresh_token: fn(_config, _refresh_token) {
+      Error(error.ConfigError(reason: "test"))
+    },
+    fetch_user: fn(_config, _exchange) {
+      Error(error.ConfigError(reason: "test"))
+    },
+  )
+}
+
+fn leaky_error_strategy() -> Strategy(e) {
+  strategy.new(
+    provider: "test",
+    default_scopes: [],
+    authorize_url: fn(_config, _scopes, _state) { Ok("https://example.com") },
+    exchange_code: fn(_config, _code, _code_verifier) {
+      Error(error.ProviderError(
+        code: "invalid_request",
+        description: "provider-controlled phishing text secret-token",
+        uri: option.None,
+      ))
+    },
+    refresh_token: fn(_config, _refresh_token) {
+      Error(error.ConfigError(reason: "test"))
+    },
+    fetch_user: fn(_config, _exchange) {
+      Error(error.ConfigError(reason: "test"))
+    },
+  )
+}
+
+fn test_config() -> config.Config {
+  config.new("client_id", "client_secret", "https://example.com/callback")
+}
+
+fn find_header(
+  headers: List(#(String, String)),
+  name: String,
+) -> Result(String, Nil) {
+  case headers {
+    [] -> Error(Nil)
+    [#(k, v), ..rest] ->
+      case k == name {
+        True -> Ok(v)
+        False -> find_header(rest, name)
+      }
+  }
+}

--- a/packages/vestibule_wisp/README.md
+++ b/packages/vestibule_wisp/README.md
@@ -139,9 +139,10 @@ decoded as UTF-8, or parsed as form data, callback handling returns
 
 ## State store
 
-`vestibule_wisp/state_store` provides the default in-memory state store backed
-by Erlang ETS. The public `StateStore` type is opaque; applications should
-create and use stores through the module functions.
+`vestibule_wisp` uses the shared `vestibule/state_store` from core
+`vestibule` — the default in-memory state store backed by Erlang ETS. The
+public `StateStore` type is opaque; applications should create and use
+stores through the module functions.
 
 - Use `try_init` or `try_init_named` when you want to handle duplicate table
   errors explicitly.
@@ -149,3 +150,5 @@ create and use stores through the module functions.
   application startup and simple examples.
 - `retrieve` consumes state exactly once.
 - Expired sessions are treated as missing and removed from the store.
+- The same store can be shared with `vestibule_mist`; a single ETS owner
+  process is shared across all transports.

--- a/packages/vestibule_wisp/gleam.toml
+++ b/packages/vestibule_wisp/gleam.toml
@@ -10,9 +10,6 @@ vestibule = { path = "../.." }
 wisp = ">= 2.2.0 and < 3.0.0"
 gleam_stdlib = ">= 0.48.0 and < 2.0.0"
 gleam_http = ">= 4.3.0 and < 5.0.0"
-gleam_json = ">= 3.1.0 and < 4.0.0"
-gleam_crypto = ">= 1.5.0 and < 2.0.0"
-gleam_time = ">= 1.7.0 and < 2.0.0"
 
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"

--- a/packages/vestibule_wisp/manifest.toml
+++ b/packages/vestibule_wisp/manifest.toml
@@ -37,16 +37,13 @@ packages = [
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
   { name = "tom", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "90791DA4AACE637E30081FE77049B8DB850FBC8CACC31515376BCC4E59BE1DD2" },
-  { name = "vestibule", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_http", "gleam_httpc", "gleam_json", "gleam_stdlib", "glow_auth"], source = "local", path = "../.." },
+  { name = "vestibule", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_http", "gleam_httpc", "gleam_json", "gleam_stdlib", "gleam_time", "glow_auth"], source = "local", path = "../.." },
   { name = "wisp", version = "2.2.0", build_tools = ["gleam"], requirements = ["directories", "exception", "filepath", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "houdini", "logging", "marceau", "mist", "simplifile"], otp_app = "wisp", source = "hex", outer_checksum = "655163D4DE19E3DD4AC75813A991BFD5523CB4FF2FC5F9F58FD6FB39D5D1806D" },
 ]
 
 [requirements]
-gleam_crypto = { version = ">= 1.5.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
-gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
-gleam_time = { version = ">= 1.7.0 and < 2.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }
 vestibule = { path = "../.." }
 wisp = { version = ">= 2.2.0 and < 3.0.0" }

--- a/packages/vestibule_wisp/src/vestibule_wisp.gleam
+++ b/packages/vestibule_wisp/src/vestibule_wisp.gleam
@@ -19,7 +19,7 @@ import vestibule/authorization_request
 import vestibule/error
 import vestibule/registry.{type Registry}
 import vestibule/state
-import vestibule_wisp/state_store.{type StateStore}
+import vestibule/state_store.{type StateStore}
 
 /// Middleware configuration options.
 pub type Options {

--- a/packages/vestibule_wisp/src/vestibule_wisp.gleam
+++ b/packages/vestibule_wisp/src/vestibule_wisp.gleam
@@ -256,7 +256,7 @@ pub fn callback_phase_auth_result_with_options(
   state_store: StateStore,
   options: Options,
 ) -> Result(Auth, CallbackError(e)) {
-  use _ <- result.try(
+  use strategy_config <- result.try(
     transport_flow.ensure_callback_provider(reg, provider)
     |> result.map_error(map_callback_flow_error),
   )
@@ -268,7 +268,12 @@ pub fn callback_phase_auth_result_with_options(
     |> result.map_error(fn(_) { MissingSessionCookie }),
   )
 
-  transport_flow.finish_callback(reg, provider, state_store, params, session_id)
+  transport_flow.finish_callback(
+    strategy_config,
+    state_store,
+    params,
+    session_id,
+  )
   |> result.map_error(map_callback_flow_error)
 }
 

--- a/packages/vestibule_wisp/src/vestibule_wisp.gleam
+++ b/packages/vestibule_wisp/src/vestibule_wisp.gleam
@@ -13,13 +13,11 @@ import gleam/result
 import gleam/uri
 import wisp.{type Request, type Response}
 
-import vestibule
 import vestibule/auth.{type Auth}
-import vestibule/authorization_request
 import vestibule/error
 import vestibule/registry.{type Registry}
-import vestibule/state
 import vestibule/state_store.{type StateStore}
+import vestibule/transport_flow
 
 /// Middleware configuration options.
 pub type Options {
@@ -72,36 +70,29 @@ pub fn request_phase_with_options(
   state_store: StateStore,
   options: Options,
 ) -> Response {
-  case registry.get(reg, provider) {
-    Error(Nil) -> wisp.not_found()
-    Ok(#(strategy, config)) ->
-      case vestibule.authorize_url(strategy, config) {
-        Ok(auth_request) -> {
-          case
-            state_store.try_store_with_ttl(
-              state_store,
-              authorization_request.state(auth_request),
-              authorization_request.code_verifier(auth_request),
-              options.session_ttl_seconds,
-            )
-          {
-            Ok(session_id) ->
-              wisp.redirect(authorization_request.url(auth_request))
-              |> wisp.set_cookie(
-                req,
-                options.cookie_name,
-                session_id,
-                wisp.Signed,
-                options.session_ttl_seconds,
-              )
-            Error(_) ->
-              error_response(error.ConfigError(
-                reason: "Failed to store OAuth session state",
-              ))
-          }
-        }
-        Error(err) -> error_response(err)
-      }
+  case
+    transport_flow.start_authorization(
+      reg,
+      provider,
+      state_store,
+      options.session_ttl_seconds,
+    )
+  {
+    Error(transport_flow.UnknownProvider(_)) -> wisp.not_found()
+    Error(transport_flow.AuthFailed(err)) -> error_response(err)
+    Error(transport_flow.StoreFailed(_)) ->
+      error_response(error.ConfigError(
+        reason: "Failed to store OAuth session state",
+      ))
+    Ok(#(url, session_id)) ->
+      wisp.redirect(url)
+      |> wisp.set_cookie(
+        req,
+        options.cookie_name,
+        session_id,
+        wisp.Signed,
+        options.session_ttl_seconds,
+      )
   }
 }
 
@@ -231,46 +222,20 @@ pub fn callback_phase_auth_result_with_options(
   state_store: StateStore,
   options: Options,
 ) -> Result(Auth, CallbackError(e)) {
-  use #(strategy, config) <- result.try(
-    registry.get(reg, provider)
-    |> result.map_error(fn(_) { UnknownProvider(provider) }),
+  use _ <- result.try(
+    transport_flow.ensure_callback_provider(reg, provider)
+    |> result.map_error(map_callback_flow_error),
   )
 
   use params <- result.try(get_callback_params(req))
-
-  use received_state <- result.try(
-    dict.get(params, "state")
-    |> result.replace_error(AuthFailed(error.MissingCallbackParam("state"))),
-  )
 
   use session_id <- result.try(
     wisp.get_cookie(req, options.cookie_name, wisp.Signed)
     |> result.map_error(fn(_) { MissingSessionCookie }),
   )
 
-  use #(expected_state, _code_verifier) <- result.try(
-    state_store.peek(state_store, session_id)
-    |> result.map_error(fn(_) { SessionExpired }),
-  )
-
-  use _ <- result.try(
-    state.validate(received_state, expected_state)
-    |> result.map_error(AuthFailed),
-  )
-
-  use #(expected_state, code_verifier) <- result.try(
-    state_store.retrieve(state_store, session_id)
-    |> result.map_error(fn(_) { SessionExpired }),
-  )
-
-  vestibule.handle_callback(
-    strategy,
-    config,
-    params,
-    expected_state,
-    code_verifier,
-  )
-  |> result.map_error(AuthFailed)
+  transport_flow.finish_callback(reg, provider, state_store, params, session_id)
+  |> result.map_error(map_callback_flow_error)
 }
 
 /// Extract callback parameters from either query string (GET) or
@@ -304,6 +269,17 @@ fn get_callback_params(
       }
     }
     _ -> Ok(dict.from_list(query_params))
+  }
+}
+
+fn map_callback_flow_error(
+  err: transport_flow.CallbackFlowError(e),
+) -> CallbackError(e) {
+  case err {
+    transport_flow.CallbackUnknownProvider(provider) ->
+      UnknownProvider(provider)
+    transport_flow.CallbackSessionUnavailable -> SessionExpired
+    transport_flow.CallbackAuthFailed(err) -> AuthFailed(err)
   }
 }
 

--- a/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
+++ b/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
@@ -6,90 +6,14 @@ import startest/expect
 import vestibule/config
 import vestibule/error
 import vestibule/registry
+import vestibule/state_store
 import vestibule/strategy.{type Strategy}
 import vestibule_wisp
-import vestibule_wisp/state_store
 import wisp
 import wisp/simulate
 
 pub fn main() -> Nil {
   startest.run(startest.default_config())
-}
-
-pub fn store_and_retrieve_state_and_verifier_test() {
-  let table = state_store.init_named("test_store_retrieve")
-  let state = "test-csrf-state-value"
-  let verifier = "test-pkce-code-verifier"
-  let session_id = state_store.store(table, state, verifier)
-  state_store.retrieve(table, session_id)
-  |> expect.to_be_ok()
-  |> expect.to_equal(#(state, verifier))
-}
-
-pub fn retrieve_deletes_after_use_test() {
-  let table = state_store.init_named("test_delete_after_use")
-  let session_id =
-    state_store.store(table, "one-time-state", "one-time-verifier")
-  let _ = state_store.retrieve(table, session_id)
-  state_store.retrieve(table, session_id)
-  |> expect.to_be_error()
-}
-
-pub fn retrieve_unknown_returns_error_test() {
-  let table = state_store.init_named("test_unknown_returns_error")
-  state_store.retrieve(table, "nonexistent-session-id")
-  |> expect.to_be_error()
-}
-
-pub fn try_init_named_returns_error_for_duplicate_table_test() {
-  let name = "vestibule_wisp_duplicate_test"
-  let assert Ok(_) = state_store.try_init_named(name)
-  let result = state_store.try_init_named(name)
-  let _ = result |> expect.to_be_error()
-  Nil
-}
-
-pub fn state_store_survives_creator_process_exit_test() {
-  state_store_survives_creator_process_exit()
-  |> expect.to_be_true()
-}
-
-pub fn try_store_returns_session_id_and_retrievable_value_test() {
-  let assert Ok(table) =
-    state_store.try_init_named("vestibule_wisp_try_store_test")
-  let state = "state"
-  let verifier = "verifier"
-  let assert Ok(session_id) = state_store.try_store(table, state, verifier)
-
-  { string.length(session_id) > 0 } |> expect.to_be_true()
-  state_store.retrieve(table, session_id)
-  |> expect.to_be_ok()
-  |> expect.to_equal(#(state, verifier))
-}
-
-pub fn try_store_with_ttl_stores_retrievable_value_test() {
-  let assert Ok(table) =
-    state_store.try_init_named("vestibule_wisp_try_store_ttl_test")
-  let state = "state"
-  let verifier = "verifier"
-  let assert Ok(session_id) =
-    state_store.try_store_with_ttl(table, state, verifier, 600)
-
-  state_store.retrieve(table, session_id)
-  |> expect.to_be_ok()
-  |> expect.to_equal(#(state, verifier))
-}
-
-pub fn retrieve_consumes_expired_session_test() {
-  let assert Ok(table) =
-    state_store.try_init_named("vestibule_wisp_expired_session_test")
-  let assert Ok(session_id) =
-    state_store.try_store_with_ttl(table, "state", "verifier", 0)
-
-  state_store.retrieve(table, session_id)
-  |> expect.to_be_error()
-  state_store.retrieve(table, session_id)
-  |> expect.to_be_error()
 }
 
 pub fn callback_phase_auth_result_unknown_provider_test() {
@@ -233,9 +157,6 @@ fn leaky_error_strategy() -> Strategy(e) {
 fn test_config() -> config.Config {
   config.new("client_id", "client_secret", "https://example.com/callback")
 }
-
-@external(erlang, "vestibule_wisp_state_store_test_ffi", "state_store_survives_creator_process_exit")
-fn state_store_survives_creator_process_exit() -> Bool
 
 pub fn callback_phase_default_error_response_does_not_render_provider_details_test() {
   let store = state_store.init_named("test_callback_generic_error_html")

--- a/src/vestibule/state_store.gleam
+++ b/src/vestibule/state_store.gleam
@@ -9,6 +9,7 @@
 import gleam/bit_array
 import gleam/crypto
 import gleam/order
+import gleam/result
 import gleam/time/duration
 import gleam/time/timestamp
 
@@ -34,8 +35,13 @@ type SessionState {
 
 /// Errors returned by checked state store operations.
 pub type StateStoreError {
+  OwnerUnavailable
+  OperationTimedOut
+  TableAlreadyExists
   TableCreateFailed
+  TableNotFound
   InsertFailed
+  CleanupFailed
 }
 
 /// Initialize the state store. Call once per VM at application startup.
@@ -58,12 +64,13 @@ pub fn try_init() -> Result(StateStore, StateStoreError) {
   try_init_named("vestibule_sessions")
 }
 
-/// Try to initialize a named state store. Returns `Error(TableCreateFailed)`
-/// if the table already exists or cannot be created.
+/// Try to initialize a named state store. Returns `Error(TableAlreadyExists)`
+/// if the table already exists, or another `StateStoreError` if the owner
+/// process or ETS operation fails.
 pub fn try_init_named(name: String) -> Result(StateStore, StateStoreError) {
   case create_table(name) {
     Ok(table) -> Ok(StateStore(table))
-    Error(_) -> Error(TableCreateFailed)
+    Error(reason) -> Error(map_create_error(reason))
   }
 }
 
@@ -95,6 +102,11 @@ pub fn try_store_with_ttl(
   code_verifier: String,
   ttl_seconds: Int,
 ) -> Result(String, StateStoreError) {
+  use _ <- result.try(
+    cleanup_expired(table.table, timestamp.system_time())
+    |> result.map_error(map_cleanup_error),
+  )
+
   let session_id =
     crypto.strong_random_bytes(16)
     |> bit_array.base64_url_encode(False)
@@ -110,13 +122,14 @@ pub fn try_store_with_ttl(
     )
   {
     Ok(Nil) -> Ok(session_id)
-    Error(_) -> Error(InsertFailed)
+    Error(reason) -> Error(map_insert_error(reason))
   }
 }
 
-/// Retrieve and consume a CSRF state and code verifier by session ID.
-/// Returns Error(Nil) if not found or already consumed (one-time use).
-pub fn retrieve(
+/// Consume a CSRF state and code verifier by session ID.
+///
+/// Returns `Error(Nil)` if not found, expired, or already consumed.
+pub fn consume(
   table: StateStore,
   session_id: String,
 ) -> Result(#(String, String), Nil) {
@@ -124,6 +137,17 @@ pub fn retrieve(
     Ok(session) -> validate_session(session)
     Error(_) -> Error(Nil)
   }
+}
+
+/// Retrieve and consume a CSRF state and code verifier by session ID.
+///
+/// Alias for `consume`. Returns `Error(Nil)` if not found, expired, or already
+/// consumed.
+pub fn retrieve(
+  table: StateStore,
+  session_id: String,
+) -> Result(#(String, String), Nil) {
+  consume(table, session_id)
 }
 
 /// Look up a CSRF state and code verifier by session ID without consuming it.
@@ -139,11 +163,40 @@ pub fn peek(
         Ok(value) -> Ok(value)
         Error(Nil) -> {
           let _ = delete_key(table.table, session_id)
+          let _ = cleanup_expired(table.table, timestamp.system_time())
           Error(Nil)
         }
       }
     }
     Error(_) -> Error(Nil)
+  }
+}
+
+fn map_create_error(reason: String) -> StateStoreError {
+  case reason {
+    "owner_init_failed" | "owner_unavailable" -> OwnerUnavailable
+    "timeout" -> OperationTimedOut
+    "table_already_exists" -> TableAlreadyExists
+    "table_not_found" -> TableNotFound
+    _ -> TableCreateFailed
+  }
+}
+
+fn map_insert_error(reason: String) -> StateStoreError {
+  case reason {
+    "owner_init_failed" | "owner_unavailable" -> OwnerUnavailable
+    "timeout" -> OperationTimedOut
+    "table_not_found" -> TableNotFound
+    _ -> InsertFailed
+  }
+}
+
+fn map_cleanup_error(reason: String) -> StateStoreError {
+  case reason {
+    "owner_init_failed" | "owner_unavailable" -> OwnerUnavailable
+    "timeout" -> OperationTimedOut
+    "table_not_found" -> TableNotFound
+    _ -> CleanupFailed
   }
 }
 
@@ -159,16 +212,26 @@ fn validate_session(session: SessionState) -> Result(#(String, String), Nil) {
 // is incompatible with current Gleam dependencies. Prefer replacing this with
 // Bravo again once a compatible Bravo version is available on Hex.
 @external(erlang, "vestibule_state_store_ffi", "create_table")
-fn create_table(name: String) -> Result(EtsTable, Nil)
+fn create_table(name: String) -> Result(EtsTable, String)
 
 @external(erlang, "vestibule_state_store_ffi", "insert")
-fn insert(table: EtsTable, key: String, value: SessionState) -> Result(Nil, Nil)
+fn insert(
+  table: EtsTable,
+  key: String,
+  value: SessionState,
+) -> Result(Nil, String)
 
 @external(erlang, "vestibule_state_store_ffi", "take")
-fn take(table: EtsTable, key: String) -> Result(SessionState, Nil)
+fn take(table: EtsTable, key: String) -> Result(SessionState, String)
 
 @external(erlang, "vestibule_state_store_ffi", "lookup")
-fn lookup(table: EtsTable, key: String) -> Result(SessionState, Nil)
+fn lookup(table: EtsTable, key: String) -> Result(SessionState, String)
 
 @external(erlang, "vestibule_state_store_ffi", "delete_key")
-fn delete_key(table: EtsTable, key: String) -> Result(Nil, Nil)
+fn delete_key(table: EtsTable, key: String) -> Result(Nil, String)
+
+@external(erlang, "vestibule_state_store_ffi", "cleanup_expired")
+fn cleanup_expired(
+  table: EtsTable,
+  now: timestamp.Timestamp,
+) -> Result(Int, String)

--- a/src/vestibule/state_store.gleam
+++ b/src/vestibule/state_store.gleam
@@ -139,17 +139,6 @@ pub fn consume(
   }
 }
 
-/// Retrieve and consume a CSRF state and code verifier by session ID.
-///
-/// Alias for `consume`. Returns `Error(Nil)` if not found, expired, or already
-/// consumed.
-pub fn retrieve(
-  table: StateStore,
-  session_id: String,
-) -> Result(#(String, String), Nil) {
-  consume(table, session_id)
-}
-
 /// Look up a CSRF state and code verifier by session ID without consuming it.
 ///
 /// Expired sessions are treated as missing and removed from the store.

--- a/src/vestibule/state_store.gleam
+++ b/src/vestibule/state_store.gleam
@@ -1,6 +1,10 @@
 //// Single-use storage for in-flight OAuth flow state (CSRF `state` and
 //// PKCE `code_verifier`). Entries are deleted on first read to prevent
 //// replay.
+////
+//// This is the shared store used by transport packages (`vestibule_wisp`,
+//// `vestibule_mist`, etc.). Applications that load more than one
+//// transport share a single ETS owner process and may share a store.
 
 import gleam/bit_array
 import gleam/crypto
@@ -38,20 +42,20 @@ pub type StateStoreError {
 /// Returns the table handle needed by store/retrieve.
 pub fn init() -> StateStore {
   let assert Ok(table) = try_init()
-    as "vestibule_wisp state store must be initialized once per VM"
+    as "vestibule state store must be initialized once per VM"
   table
 }
 
 /// Initialize a named state store. Useful for testing with isolated tables.
 pub fn init_named(name: String) -> StateStore {
   let assert Ok(table) = try_init_named(name)
-    as "vestibule_wisp named state store must be initialized once per VM"
+    as "vestibule named state store must be initialized once per VM"
   table
 }
 
 /// Try to initialize the state store.
 pub fn try_init() -> Result(StateStore, StateStoreError) {
-  try_init_named("vestibule_wisp_sessions")
+  try_init_named("vestibule_sessions")
 }
 
 /// Try to initialize a named state store. Returns `Error(TableCreateFailed)`
@@ -70,7 +74,7 @@ pub fn store(
   code_verifier: String,
 ) -> String {
   let assert Ok(session_id) = try_store(table, state, code_verifier)
-    as "vestibule_wisp failed to store OAuth session state"
+    as "vestibule failed to store OAuth session state"
   session_id
 }
 
@@ -154,17 +158,17 @@ fn validate_session(session: SessionState) -> Result(#(String, String), Nil) {
 // Direct ETS FFI keeps this package Hex-publishable while Bravo's Hex release
 // is incompatible with current Gleam dependencies. Prefer replacing this with
 // Bravo again once a compatible Bravo version is available on Hex.
-@external(erlang, "vestibule_wisp_state_store_ffi", "create_table")
+@external(erlang, "vestibule_state_store_ffi", "create_table")
 fn create_table(name: String) -> Result(EtsTable, Nil)
 
-@external(erlang, "vestibule_wisp_state_store_ffi", "insert")
+@external(erlang, "vestibule_state_store_ffi", "insert")
 fn insert(table: EtsTable, key: String, value: SessionState) -> Result(Nil, Nil)
 
-@external(erlang, "vestibule_wisp_state_store_ffi", "take")
+@external(erlang, "vestibule_state_store_ffi", "take")
 fn take(table: EtsTable, key: String) -> Result(SessionState, Nil)
 
-@external(erlang, "vestibule_wisp_state_store_ffi", "lookup")
+@external(erlang, "vestibule_state_store_ffi", "lookup")
 fn lookup(table: EtsTable, key: String) -> Result(SessionState, Nil)
 
-@external(erlang, "vestibule_wisp_state_store_ffi", "delete_key")
+@external(erlang, "vestibule_state_store_ffi", "delete_key")
 fn delete_key(table: EtsTable, key: String) -> Result(Nil, Nil)

--- a/src/vestibule/transport_flow.gleam
+++ b/src/vestibule/transport_flow.gleam
@@ -6,10 +6,12 @@ import gleam/result
 import vestibule
 import vestibule/auth.{type Auth}
 import vestibule/authorization_request
+import vestibule/config.{type Config}
 import vestibule/error.{type AuthError}
 import vestibule/registry.{type Registry}
 import vestibule/state
 import vestibule/state_store.{type StateStore, type StateStoreError}
+import vestibule/strategy.{type Strategy}
 
 /// Errors that can occur while starting an authorization flow.
 pub type RequestFlowError(e) {
@@ -53,31 +55,32 @@ pub fn start_authorization(
   Ok(#(authorization_request.url(auth_request), session_id))
 }
 
-/// Validate callback state, consume the stored verifier, and fetch auth data.
+/// Look up the provider's strategy and config without touching cookies,
+/// request bodies, or the state store.
 ///
-/// Transports that need to preserve provider-lookup precedence before parsing
-/// cookies or request bodies can call this helper first.
+/// Transports call this first so that an unknown provider returns
+/// `CallbackUnknownProvider` before any cookie or request-body parsing
+/// happens. The returned strategy/config pair is threaded into
+/// `finish_callback` to avoid a second registry lookup.
 pub fn ensure_callback_provider(
   provider_registry: Registry(e),
   provider: String,
-) -> Result(Nil, CallbackFlowError(e)) {
+) -> Result(#(Strategy(e), Config), CallbackFlowError(e)) {
   registry.get(provider_registry, provider)
-  |> result.map(fn(_) { Nil })
   |> result.map_error(fn(_) { CallbackUnknownProvider(provider) })
 }
 
 /// Validate callback state, consume the stored verifier, and fetch auth data.
+///
+/// Pass the strategy/config pair returned by `ensure_callback_provider` to
+/// reuse the provider lookup instead of querying the registry again.
 pub fn finish_callback(
-  provider_registry: Registry(e),
-  provider: String,
+  strategy_config: #(Strategy(e), Config),
   store: StateStore,
   params: Dict(String, String),
   session_id: String,
 ) -> Result(Auth, CallbackFlowError(e)) {
-  use #(strategy, config) <- result.try(
-    registry.get(provider_registry, provider)
-    |> result.map_error(fn(_) { CallbackUnknownProvider(provider) }),
-  )
+  let #(strategy, config) = strategy_config
 
   use received_state <- result.try(
     dict.get(params, "state")

--- a/src/vestibule/transport_flow.gleam
+++ b/src/vestibule/transport_flow.gleam
@@ -1,0 +1,112 @@
+//// Transport-independent OAuth request and callback flow helpers.
+
+import gleam/dict.{type Dict}
+import gleam/result
+
+import vestibule
+import vestibule/auth.{type Auth}
+import vestibule/authorization_request
+import vestibule/error.{type AuthError}
+import vestibule/registry.{type Registry}
+import vestibule/state
+import vestibule/state_store.{type StateStore, type StateStoreError}
+
+/// Errors that can occur while starting an authorization flow.
+pub type RequestFlowError(e) {
+  UnknownProvider(provider: String)
+  AuthFailed(AuthError(e))
+  StoreFailed(StateStoreError)
+}
+
+/// Errors that can occur while finishing a callback flow.
+pub type CallbackFlowError(e) {
+  CallbackUnknownProvider(provider: String)
+  CallbackSessionUnavailable
+  CallbackAuthFailed(AuthError(e))
+}
+
+/// Generate an authorization URL and store the expected state/verifier.
+pub fn start_authorization(
+  provider_registry: Registry(e),
+  provider: String,
+  store: StateStore,
+  ttl_seconds: Int,
+) -> Result(#(String, String), RequestFlowError(e)) {
+  use #(strategy, config) <- result.try(
+    registry.get(provider_registry, provider)
+    |> result.map_error(fn(_) { UnknownProvider(provider) }),
+  )
+  use auth_request <- result.try(
+    vestibule.authorize_url(strategy, config)
+    |> result.map_error(AuthFailed),
+  )
+  use session_id <- result.try(
+    state_store.try_store_with_ttl(
+      store,
+      authorization_request.state(auth_request),
+      authorization_request.code_verifier(auth_request),
+      ttl_seconds,
+    )
+    |> result.map_error(StoreFailed),
+  )
+
+  Ok(#(authorization_request.url(auth_request), session_id))
+}
+
+/// Validate callback state, consume the stored verifier, and fetch auth data.
+///
+/// Transports that need to preserve provider-lookup precedence before parsing
+/// cookies or request bodies can call this helper first.
+pub fn ensure_callback_provider(
+  provider_registry: Registry(e),
+  provider: String,
+) -> Result(Nil, CallbackFlowError(e)) {
+  registry.get(provider_registry, provider)
+  |> result.map(fn(_) { Nil })
+  |> result.map_error(fn(_) { CallbackUnknownProvider(provider) })
+}
+
+/// Validate callback state, consume the stored verifier, and fetch auth data.
+pub fn finish_callback(
+  provider_registry: Registry(e),
+  provider: String,
+  store: StateStore,
+  params: Dict(String, String),
+  session_id: String,
+) -> Result(Auth, CallbackFlowError(e)) {
+  use #(strategy, config) <- result.try(
+    registry.get(provider_registry, provider)
+    |> result.map_error(fn(_) { CallbackUnknownProvider(provider) }),
+  )
+
+  use received_state <- result.try(
+    dict.get(params, "state")
+    |> result.replace_error(
+      CallbackAuthFailed(error.MissingCallbackParam("state")),
+    ),
+  )
+
+  use #(expected_state, _code_verifier) <- result.try(
+    state_store.peek(store, session_id)
+    |> result.map_error(fn(_) { CallbackSessionUnavailable }),
+  )
+
+  use _ <- result.try(
+    state.validate(received_state, expected_state)
+    |> result.map_error(CallbackAuthFailed),
+  )
+
+  use #(_, code_verifier) <- result.try(
+    state_store.consume(store, session_id)
+    |> result.map_error(fn(_) { CallbackSessionUnavailable }),
+  )
+
+  vestibule.handle_callback(
+    strategy,
+    config,
+    params,
+    expected_state,
+    code_verifier,
+  )
+  |> result.map_error(CallbackAuthFailed)
+}

--- a/src/vestibule_state_store_ffi.erl
+++ b/src/vestibule_state_store_ffi.erl
@@ -1,8 +1,8 @@
--module(vestibule_wisp_state_store_ffi).
+-module(vestibule_state_store_ffi).
 
 -export([create_table/1, insert/3, take/2, lookup/2, delete_key/2]).
 
--define(SERVER, vestibule_wisp_state_store_owner).
+-define(SERVER, vestibule_state_store_owner).
 
 create_table(Name) ->
     call({create, Name}).
@@ -63,7 +63,7 @@ loop(Tables) ->
                     loop(Tables);
                 false ->
                     try
-                        Table = ets:new(vestibule_wisp_state_store,
+                        Table = ets:new(vestibule_state_store,
                                         [set, protected]),
                         From ! {Ref, {ok, Name}},
                         loop(maps:put(Name, Table, Tables))

--- a/src/vestibule_state_store_ffi.erl
+++ b/src/vestibule_state_store_ffi.erl
@@ -1,6 +1,7 @@
 -module(vestibule_state_store_ffi).
 
--export([create_table/1, insert/3, take/2, lookup/2, delete_key/2]).
+-export([create_table/1, insert/3, take/2, lookup/2, delete_key/2,
+         cleanup_expired/2, count/1]).
 
 -define(SERVER, vestibule_state_store_owner).
 
@@ -19,18 +20,29 @@ lookup(Table, Key) ->
 delete_key(Table, Key) ->
     call({delete_key, Table, Key}).
 
+cleanup_expired(Table, Now) ->
+    call({cleanup_expired, Table, Now}).
+
+count(Table) ->
+    call({count, Table}).
+
 call(Request) ->
     case ensure_owner() of
         ok ->
             Ref = make_ref(),
-            ?SERVER ! {self(), Ref, Request},
-            receive
-                {Ref, Reply} -> Reply
-            after 5000 ->
-                {error, nil}
+            try
+                ?SERVER ! {self(), Ref, Request},
+                receive
+                    {Ref, Reply} -> Reply
+                after 5000 ->
+                    {error, <<"timeout">>}
+                end
+            catch
+                _:_ ->
+                    {error, <<"owner_unavailable">>}
             end;
         error ->
-            {error, nil}
+            {error, <<"owner_init_failed">>}
     end.
 
 ensure_owner() ->
@@ -48,6 +60,7 @@ ensure_owner() ->
                         _ -> ok
                     end;
                 _:_ ->
+                    exit(Pid, kill),
                     error
             end;
         _ ->
@@ -59,7 +72,7 @@ loop(Tables) ->
         {From, Ref, {create, Name}} ->
             case maps:is_key(Name, Tables) of
                 true ->
-                    From ! {Ref, {error, nil}},
+                    From ! {Ref, {error, <<"table_already_exists">>}},
                     loop(Tables);
                 false ->
                     try
@@ -69,7 +82,7 @@ loop(Tables) ->
                         loop(maps:put(Name, Table, Tables))
                     catch
                         _:_ ->
-                            From ! {Ref, {error, nil}},
+                            From ! {Ref, {error, <<"table_create_failed">>}},
                             loop(Tables)
                     end
             end;
@@ -100,6 +113,17 @@ loop(Tables) ->
                 ets:delete(Table, Key),
                 {ok, nil}
             end)},
+            loop(Tables);
+        {From, Ref, {cleanup_expired, Name, Now}} ->
+            From ! {Ref, with_table(Name, Tables, fun(Table) ->
+                Count = cleanup_expired_entries(Table, Now),
+                {ok, Count}
+            end)},
+            loop(Tables);
+        {From, Ref, {count, Name}} ->
+            From ! {Ref, with_table(Name, Tables, fun(Table) ->
+                {ok, ets:info(Table, size)}
+            end)},
             loop(Tables)
     end.
 
@@ -107,8 +131,27 @@ with_table(Name, Tables, Fun) ->
     case maps:find(Name, Tables) of
         {ok, Table} ->
             try Fun(Table)
-            catch _:_ -> {error, nil}
+            catch _:_ -> {error, <<"ets_operation_failed">>}
             end;
         error ->
-            {error, nil}
+            {error, <<"table_not_found">>}
     end.
+
+cleanup_expired_entries(Table, Now) ->
+    ets:foldl(fun
+        ({Key, {session_state, _State, _Verifier, ExpiresAt}}, Count) ->
+            case timestamp_lte(ExpiresAt, Now) of
+                true ->
+                    ets:delete(Table, Key),
+                    Count + 1;
+                false ->
+                    Count
+            end;
+        (_, Count) ->
+            Count
+    end, 0, Table).
+
+timestamp_lte({timestamp, LeftSeconds, LeftNanoseconds},
+              {timestamp, RightSeconds, RightNanoseconds}) ->
+    LeftSeconds < RightSeconds orelse
+        (LeftSeconds =:= RightSeconds andalso LeftNanoseconds =< RightNanoseconds).

--- a/test/vestibule/state_store_test.gleam
+++ b/test/vestibule/state_store_test.gleam
@@ -21,6 +21,16 @@ pub fn retrieve_deletes_after_use_test() {
   |> expect.to_be_error()
 }
 
+pub fn consume_deletes_after_use_test() {
+  let table = state_store.init_named("test_consume_delete_after_use")
+  let session_id =
+    state_store.store(table, "one-time-state", "one-time-verifier")
+  state_store.consume(table, session_id)
+  |> expect.to_be_ok()
+  state_store.consume(table, session_id)
+  |> expect.to_be_error()
+}
+
 pub fn retrieve_unknown_returns_error_test() {
   let table = state_store.init_named("test_unknown_returns_error")
   state_store.retrieve(table, "nonexistent-session-id")
@@ -31,8 +41,7 @@ pub fn try_init_named_returns_error_for_duplicate_table_test() {
   let name = "vestibule_duplicate_test"
   let assert Ok(_) = state_store.try_init_named(name)
   let result = state_store.try_init_named(name)
-  let _ = result |> expect.to_be_error()
-  Nil
+  result |> expect.to_equal(Error(state_store.TableAlreadyExists))
 }
 
 pub fn state_store_survives_creator_process_exit_test() {
@@ -77,5 +86,22 @@ pub fn retrieve_consumes_expired_session_test() {
   |> expect.to_be_error()
 }
 
+pub fn storing_new_session_removes_expired_sessions_test() {
+  let name = "vestibule_cleanup_expired_session_test"
+  let assert Ok(table) = state_store.try_init_named(name)
+  let assert Ok(_) =
+    state_store.try_store_with_ttl(table, "expired-state", "verifier", 0)
+
+  count_store_entries(name) |> expect.to_equal(1)
+
+  let assert Ok(_) =
+    state_store.try_store_with_ttl(table, "fresh-state", "verifier", 600)
+
+  count_store_entries(name) |> expect.to_equal(1)
+}
+
 @external(erlang, "vestibule_state_store_test_ffi", "state_store_survives_creator_process_exit")
 fn state_store_survives_creator_process_exit() -> Bool
+
+@external(erlang, "vestibule_state_store_test_ffi", "count_store_entries")
+fn count_store_entries(name: String) -> Int

--- a/test/vestibule/state_store_test.gleam
+++ b/test/vestibule/state_store_test.gleam
@@ -7,7 +7,7 @@ pub fn store_and_retrieve_state_and_verifier_test() {
   let state = "test-csrf-state-value"
   let verifier = "test-pkce-code-verifier"
   let session_id = state_store.store(table, state, verifier)
-  state_store.retrieve(table, session_id)
+  state_store.consume(table, session_id)
   |> expect.to_be_ok()
   |> expect.to_equal(#(state, verifier))
 }
@@ -16,8 +16,8 @@ pub fn retrieve_deletes_after_use_test() {
   let table = state_store.init_named("test_delete_after_use")
   let session_id =
     state_store.store(table, "one-time-state", "one-time-verifier")
-  let _ = state_store.retrieve(table, session_id)
-  state_store.retrieve(table, session_id)
+  let _ = state_store.consume(table, session_id)
+  state_store.consume(table, session_id)
   |> expect.to_be_error()
 }
 
@@ -33,7 +33,7 @@ pub fn consume_deletes_after_use_test() {
 
 pub fn retrieve_unknown_returns_error_test() {
   let table = state_store.init_named("test_unknown_returns_error")
-  state_store.retrieve(table, "nonexistent-session-id")
+  state_store.consume(table, "nonexistent-session-id")
   |> expect.to_be_error()
 }
 
@@ -56,7 +56,7 @@ pub fn try_store_returns_session_id_and_retrievable_value_test() {
   let assert Ok(session_id) = state_store.try_store(table, state, verifier)
 
   { string.length(session_id) > 0 } |> expect.to_be_true()
-  state_store.retrieve(table, session_id)
+  state_store.consume(table, session_id)
   |> expect.to_be_ok()
   |> expect.to_equal(#(state, verifier))
 }
@@ -69,7 +69,7 @@ pub fn try_store_with_ttl_stores_retrievable_value_test() {
   let assert Ok(session_id) =
     state_store.try_store_with_ttl(table, state, verifier, 600)
 
-  state_store.retrieve(table, session_id)
+  state_store.consume(table, session_id)
   |> expect.to_be_ok()
   |> expect.to_equal(#(state, verifier))
 }
@@ -80,9 +80,9 @@ pub fn retrieve_consumes_expired_session_test() {
   let assert Ok(session_id) =
     state_store.try_store_with_ttl(table, "state", "verifier", 0)
 
-  state_store.retrieve(table, session_id)
+  state_store.consume(table, session_id)
   |> expect.to_be_error()
-  state_store.retrieve(table, session_id)
+  state_store.consume(table, session_id)
   |> expect.to_be_error()
 }
 

--- a/test/vestibule/state_store_test.gleam
+++ b/test/vestibule/state_store_test.gleam
@@ -1,0 +1,81 @@
+import gleam/string
+import startest/expect
+import vestibule/state_store
+
+pub fn store_and_retrieve_state_and_verifier_test() {
+  let table = state_store.init_named("test_store_retrieve")
+  let state = "test-csrf-state-value"
+  let verifier = "test-pkce-code-verifier"
+  let session_id = state_store.store(table, state, verifier)
+  state_store.retrieve(table, session_id)
+  |> expect.to_be_ok()
+  |> expect.to_equal(#(state, verifier))
+}
+
+pub fn retrieve_deletes_after_use_test() {
+  let table = state_store.init_named("test_delete_after_use")
+  let session_id =
+    state_store.store(table, "one-time-state", "one-time-verifier")
+  let _ = state_store.retrieve(table, session_id)
+  state_store.retrieve(table, session_id)
+  |> expect.to_be_error()
+}
+
+pub fn retrieve_unknown_returns_error_test() {
+  let table = state_store.init_named("test_unknown_returns_error")
+  state_store.retrieve(table, "nonexistent-session-id")
+  |> expect.to_be_error()
+}
+
+pub fn try_init_named_returns_error_for_duplicate_table_test() {
+  let name = "vestibule_duplicate_test"
+  let assert Ok(_) = state_store.try_init_named(name)
+  let result = state_store.try_init_named(name)
+  let _ = result |> expect.to_be_error()
+  Nil
+}
+
+pub fn state_store_survives_creator_process_exit_test() {
+  state_store_survives_creator_process_exit()
+  |> expect.to_be_true()
+}
+
+pub fn try_store_returns_session_id_and_retrievable_value_test() {
+  let assert Ok(table) = state_store.try_init_named("vestibule_try_store_test")
+  let state = "state"
+  let verifier = "verifier"
+  let assert Ok(session_id) = state_store.try_store(table, state, verifier)
+
+  { string.length(session_id) > 0 } |> expect.to_be_true()
+  state_store.retrieve(table, session_id)
+  |> expect.to_be_ok()
+  |> expect.to_equal(#(state, verifier))
+}
+
+pub fn try_store_with_ttl_stores_retrievable_value_test() {
+  let assert Ok(table) =
+    state_store.try_init_named("vestibule_try_store_ttl_test")
+  let state = "state"
+  let verifier = "verifier"
+  let assert Ok(session_id) =
+    state_store.try_store_with_ttl(table, state, verifier, 600)
+
+  state_store.retrieve(table, session_id)
+  |> expect.to_be_ok()
+  |> expect.to_equal(#(state, verifier))
+}
+
+pub fn retrieve_consumes_expired_session_test() {
+  let assert Ok(table) =
+    state_store.try_init_named("vestibule_expired_session_test")
+  let assert Ok(session_id) =
+    state_store.try_store_with_ttl(table, "state", "verifier", 0)
+
+  state_store.retrieve(table, session_id)
+  |> expect.to_be_error()
+  state_store.retrieve(table, session_id)
+  |> expect.to_be_error()
+}
+
+@external(erlang, "vestibule_state_store_test_ffi", "state_store_survives_creator_process_exit")
+fn state_store_survives_creator_process_exit() -> Bool

--- a/test/vestibule_state_store_test_ffi.erl
+++ b/test/vestibule_state_store_test_ffi.erl
@@ -1,17 +1,17 @@
--module(vestibule_wisp_state_store_test_ffi).
+-module(vestibule_state_store_test_ffi).
 
 -export([state_store_survives_creator_process_exit/0]).
 
 state_store_survives_creator_process_exit() ->
-    Name = <<"vestibule_wisp_owner_lifetime_test">>,
+    Name = <<"vestibule_owner_lifetime_test">>,
     Key = <<"session">>,
     Value = <<"stored">>,
     Parent = self(),
     Pid = spawn(fun() ->
         Result =
-            case vestibule_wisp_state_store_ffi:create_table(Name) of
+            case vestibule_state_store_ffi:create_table(Name) of
                 {ok, Store} ->
-                    vestibule_wisp_state_store_ffi:insert(Store, Key, Value);
+                    vestibule_state_store_ffi:insert(Store, Key, Value);
                 Error ->
                     Error
             end,
@@ -29,7 +29,7 @@ state_store_survives_creator_process_exit() ->
     after 5000 ->
         false
     end,
-    case vestibule_wisp_state_store_ffi:lookup(Name, Key) of
+    case vestibule_state_store_ffi:lookup(Name, Key) of
         {ok, Value} -> true;
         _ -> false
     end.

--- a/test/vestibule_state_store_test_ffi.erl
+++ b/test/vestibule_state_store_test_ffi.erl
@@ -1,6 +1,6 @@
 -module(vestibule_state_store_test_ffi).
 
--export([state_store_survives_creator_process_exit/0]).
+-export([state_store_survives_creator_process_exit/0, count_store_entries/1]).
 
 state_store_survives_creator_process_exit() ->
     Name = <<"vestibule_owner_lifetime_test">>,
@@ -32,4 +32,10 @@ state_store_survives_creator_process_exit() ->
     case vestibule_state_store_ffi:lookup(Name, Key) of
         {ok, Value} -> true;
         _ -> false
+    end.
+
+count_store_entries(Name) ->
+    case vestibule_state_store_ffi:count(Name) of
+        {ok, Count} -> Count;
+        {error, _} -> -1
     end.


### PR DESCRIPTION
## Summary

- Add the `vestibule_mist` transport package for Mist-based OAuth flows.
- Promote the OAuth state store into core and expose consume-oriented state reads.
- Share transport-independent authorization/callback flow logic between Mist and Wisp.
- Harden state-store FFI error reporting, owner lifecycle handling, and expired-session cleanup.
- Make Mist session cookies `Secure` by default with an explicit local-development opt-out.

## Validation

- `just test-all`
- `just check`
- `just format-check`
- `git diff --check`
