### PR TITLE
fix(ci): restore changie release baseline

### DIFF
--- a/.changes/vestibule/v0.1.0.md
+++ b/.changes/vestibule/v0.1.0.md
@@ -1,0 +1,5 @@
+## v0.1.0 - 2026-05-23
+
+#### Added
+
+##### Initial public release.

--- a/.changes/vestibule_apple/v0.1.0.md
+++ b/.changes/vestibule_apple/v0.1.0.md
@@ -1,0 +1,5 @@
+## v0.1.0 - 2026-05-23
+
+#### Added
+
+##### Initial public release.

--- a/.changes/vestibule_google/v0.1.0.md
+++ b/.changes/vestibule_google/v0.1.0.md
@@ -1,0 +1,5 @@
+## v0.1.0 - 2026-05-23
+
+#### Added
+
+##### Initial public release.

--- a/.changes/vestibule_microsoft/v0.1.0.md
+++ b/.changes/vestibule_microsoft/v0.1.0.md
@@ -1,0 +1,5 @@
+## v0.1.0 - 2026-05-23
+
+#### Added
+
+##### Initial public release.

--- a/.changes/vestibule_wisp/v0.1.0.md
+++ b/.changes/vestibule_wisp/v0.1.0.md
@@ -1,0 +1,5 @@
+## v0.1.0 - 2026-05-23
+
+#### Added
+
+##### Initial public release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,6 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Read workspace
-        id: ws
-        uses: tylerbutler/actions/read-gleam-workspace@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/read-gleam-workspace@main
-
       - name: Setup environment
         uses: ./.github/actions/setup
 
@@ -32,14 +28,18 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           pr-title-template: 'release {version}'
-          projects: ${{ steps.ws.outputs.projects }}
+          projects: vestibule,vestibule_apple,vestibule_google,vestibule_microsoft,vestibule_wisp
           version-files: |
-            ${{ steps.ws.outputs.version-files }}
+            vestibule:gleam.toml:version
+            vestibule_apple:packages/vestibule_apple/gleam.toml:version
+            vestibule_google:packages/vestibule_google/gleam.toml:version
+            vestibule_microsoft:packages/vestibule_microsoft/gleam.toml:version
+            vestibule_wisp:packages/vestibule_wisp/gleam.toml:version
           post-batch-command: |
             echo "Refreshing lockfiles after version bumps..."
             gleam deps download
             for d in packages/vestibule_*/; do
-              [ -f "$d/gleam.toml" ] && (cd "$d" && gleam deps download)
+              [ -f "$d/gleam.toml" ] && rm -f "$d/manifest.toml" && (cd "$d" && gleam deps download)
             done
 
       - name: Summary


### PR DESCRIPTION
## Summary

- Seed Changie baseline version files for all packages at v0.1.0 so the next release resolves to v0.1.1 instead of v0.0.1.
- Release all Changie projects explicitly instead of deriving projects from the intentionally excluded Gleam workspace members.
- Refresh provider package lockfiles from scratch during release batching to avoid stale local path dependency versions.

## Testing

- Validated local Changie batching/merge for all projects to v0.1.1.
- Validated the release workflow post-batch lockfile refresh path.
