### PR TITLE
fix(wisp): prevent OAuth session cookie tossing

### DIFF
--- a/.changes/unreleased/vestibule_wisp-Security-20260613-050045.yaml
+++ b/.changes/unreleased/vestibule_wisp-Security-20260613-050045.yaml
@@ -1,0 +1,4 @@
+project: vestibule_wisp
+kind: Security
+body: 'The default OAuth session cookie is now host-bound (`__Host-vestibule_session`) instead of `vestibule_session`, preventing a sibling subdomain from tossing/fixating the session via a `Domain=.example.com` cookie. Added `is_host_bound_cookie_name` to validate custom cookie names.'
+time: 2026-06-13T05:00:45.000000+00:00

--- a/packages/vestibule_wisp/README.md
+++ b/packages/vestibule_wisp/README.md
@@ -64,19 +64,28 @@ For a runnable app, see `example/`.
 
 ## Options
 
-The default options preserve the existing cookie contract:
+The default options use a host-bound (`__Host-` prefixed) session cookie:
 
 ```gleam
 vestibule_wisp.default_options()
-// -> Options(cookie_name: "vestibule_session", session_ttl_seconds: 600)
+// -> Options(cookie_name: "__Host-vestibule_session", session_ttl_seconds: 600)
 ```
 
-Use the `_with_options` functions to customize the cookie name or session TTL:
+The `__Host-` prefix defends against OAuth session cookie tossing / fixation:
+browsers only accept a `__Host-` cookie when it is set with `Secure`, `Path=/`,
+and no `Domain` attribute, so a sibling subdomain cannot overwrite it with a
+`Domain=.example.com` cookie of the same name. `wisp.set_cookie` already sets
+those attributes, so the default cookie meets the `__Host-` requirements.
+
+Use the `_with_options` functions to customize the cookie name or session TTL.
+**Keep the `__Host-` prefix on any custom cookie name** — a non-host-bound name
+re-introduces the cookie-tossing vulnerability. Use
+`vestibule_wisp.is_host_bound_cookie_name/1` to validate a caller-supplied name.
 
 ```gleam
 let options =
   vestibule_wisp.Options(
-    cookie_name: "my_app_oauth_session",
+    cookie_name: "__Host-my_app_oauth_session",
     session_ttl_seconds: 300,
   )
 

--- a/packages/vestibule_wisp/src/vestibule_wisp.gleam
+++ b/packages/vestibule_wisp/src/vestibule_wisp.gleam
@@ -10,6 +10,7 @@ import gleam/bit_array
 import gleam/dict
 import gleam/http
 import gleam/result
+import gleam/string
 import gleam/uri
 import wisp.{type Request, type Response}
 
@@ -22,6 +23,15 @@ import vestibule/state
 import vestibule_wisp/state_store.{type StateStore}
 
 /// Middleware configuration options.
+///
+/// `cookie_name` should be host-bound (use the `__Host-` prefix) to defend
+/// against OAuth session cookie tossing / fixation. A non-host-bound name such
+/// as `vestibule_session` can be overwritten by a sibling subdomain setting a
+/// `Domain=.example.com` cookie of the same name, which lets an attacker plant
+/// their own in-flight flow state and fixate the victim's session — especially
+/// dangerous in account-linking flows. The default options use a host-bound
+/// name; keep the `__Host-` prefix for any custom `cookie_name`. See
+/// `is_host_bound_cookie_name`.
 pub type Options {
   Options(cookie_name: String, session_ttl_seconds: Int)
 }
@@ -42,9 +52,33 @@ pub type CallbackError(e) {
 
 /// Default middleware options.
 ///
-/// Uses the `vestibule_session` signed cookie with a 600-second session TTL.
+/// Uses the host-bound `__Host-vestibule_session` signed cookie with a
+/// 600-second session TTL. The `__Host-` prefix makes browsers reject the
+/// cookie unless it is set with `Secure`, `Path=/`, and no `Domain` attribute,
+/// which prevents a sibling subdomain from tossing/fixating the OAuth session
+/// (see the `Options` docs). `wisp.set_cookie` already sets `Secure` (over
+/// HTTPS), `Path=/`, and no `Domain`, so this cookie meets the `__Host-`
+/// requirements.
 pub fn default_options() -> Options {
-  Options(cookie_name: "vestibule_session", session_ttl_seconds: 600)
+  Options(cookie_name: host_bound_cookie_name, session_ttl_seconds: 600)
+}
+
+/// Prefix that makes a cookie host-bound under the `__Host-` cookie name rule.
+const host_cookie_prefix: String = "__Host-"
+
+/// The default host-bound OAuth session cookie name.
+const host_bound_cookie_name: String = "__Host-vestibule_session"
+
+/// Returns `True` when `name` is host-bound (uses the `__Host-` prefix).
+///
+/// Host-bound cookie names resist cookie tossing / session fixation from
+/// sibling subdomains: browsers only accept a `__Host-` cookie when it is set
+/// with `Secure`, `Path=/`, and no `Domain` attribute, so a sibling subdomain
+/// cannot overwrite it with a `Domain=.example.com` cookie of the same name.
+/// Prefer keeping the `__Host-` prefix for any custom `Options.cookie_name`;
+/// use this to validate names supplied by callers.
+pub fn is_host_bound_cookie_name(name: String) -> Bool {
+  string.starts_with(name, host_cookie_prefix)
 }
 
 /// Phase 1: Redirect user to the OAuth provider.

--- a/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
+++ b/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
@@ -1,4 +1,5 @@
 import gleam/http
+import gleam/list
 import gleam/option
 import gleam/string
 import startest
@@ -120,9 +121,46 @@ pub fn callback_phase_auth_result_missing_session_cookie_test() {
 pub fn default_options_use_current_cookie_contract_test() {
   vestibule_wisp.default_options()
   |> expect.to_equal(vestibule_wisp.Options(
-    cookie_name: "vestibule_session",
+    cookie_name: "__Host-vestibule_session",
     session_ttl_seconds: 600,
   ))
+}
+
+pub fn default_cookie_name_is_host_bound_test() {
+  let options = vestibule_wisp.default_options()
+  vestibule_wisp.is_host_bound_cookie_name(options.cookie_name)
+  |> expect.to_be_true()
+}
+
+pub fn is_host_bound_cookie_name_rejects_non_prefixed_test() {
+  vestibule_wisp.is_host_bound_cookie_name("vestibule_session")
+  |> expect.to_be_false()
+}
+
+pub fn is_host_bound_cookie_name_accepts_host_prefixed_test() {
+  vestibule_wisp.is_host_bound_cookie_name("__Host-custom_session")
+  |> expect.to_be_true()
+}
+
+pub fn request_phase_sets_host_bound_cookie_test() {
+  let store = state_store.init_named("test_request_phase_host_bound_cookie")
+  let reg =
+    registry.new()
+    |> registry.register(test_strategy(), test_config())
+  let req = simulate.request(http.Get, "/auth/test")
+
+  let response = vestibule_wisp.request_phase(req, reg, "test", store)
+
+  let set_cookie = case list.key_find(response.headers, "set-cookie") {
+    Ok(value) -> value
+    Error(_) -> panic as "expected a set-cookie header"
+  }
+
+  { string.contains(set_cookie, "__Host-vestibule_session=") }
+  |> expect.to_be_true()
+  { string.contains(set_cookie, "Secure") } |> expect.to_be_true()
+  { string.contains(set_cookie, "Path=/") } |> expect.to_be_true()
+  { string.contains(set_cookie, "Domain=") } |> expect.to_be_false()
 }
 
 pub fn callback_phase_auth_result_with_options_uses_cookie_name_test() {
@@ -154,7 +192,7 @@ pub fn callback_phase_auth_result_malformed_post_body_returns_invalid_params_tes
   let req =
     simulate.request(http.Post, "/auth/test/callback?state=state&code=code")
     |> simulate.bit_array_body(<<255>>)
-    |> simulate.cookie("vestibule_session", session_id, wisp.Signed)
+    |> simulate.cookie("__Host-vestibule_session", session_id, wisp.Signed)
   let reg =
     registry.new()
     |> registry.register(test_strategy(), test_config())
@@ -168,10 +206,10 @@ pub fn callback_phase_auth_result_missing_state_does_not_consume_session_test() 
   let session_id = state_store.store(store, "state", "verifier")
   let req_missing_state =
     simulate.request(http.Get, "/auth/test/callback?code=code")
-    |> simulate.cookie("vestibule_session", session_id, wisp.Signed)
+    |> simulate.cookie("__Host-vestibule_session", session_id, wisp.Signed)
   let req_with_state =
     simulate.request(http.Get, "/auth/test/callback?state=state&code=code")
-    |> simulate.cookie("vestibule_session", session_id, wisp.Signed)
+    |> simulate.cookie("__Host-vestibule_session", session_id, wisp.Signed)
   let reg =
     registry.new()
     |> registry.register(test_strategy(), test_config())
@@ -242,7 +280,7 @@ pub fn callback_phase_default_error_response_does_not_render_provider_details_te
   let session_id = state_store.store(store, "state", "verifier")
   let req =
     simulate.request(http.Get, "/auth/test/callback?state=state&code=code")
-    |> simulate.cookie("vestibule_session", session_id, wisp.Signed)
+    |> simulate.cookie("__Host-vestibule_session", session_id, wisp.Signed)
   let reg =
     registry.new()
     |> registry.register(leaky_error_strategy(), test_config())
@@ -268,7 +306,7 @@ pub fn callback_phase_auth_result_preserves_provider_error_details_test() {
   let session_id = state_store.store(store, "state", "verifier")
   let req =
     simulate.request(http.Get, "/auth/test/callback?state=state&code=code")
-    |> simulate.cookie("vestibule_session", session_id, wisp.Signed)
+    |> simulate.cookie("__Host-vestibule_session", session_id, wisp.Signed)
   let reg =
     registry.new()
     |> registry.register(leaky_error_strategy(), test_config())


### PR DESCRIPTION
## Summary

Fixes #55 (security). The `vestibule_wisp` middleware used `vestibule_session` — a non-host-bound name — as the default OAuth session cookie. A sibling subdomain can set a `Domain=.example.com` cookie of the same name and toss/fixate the victim's in-flight OAuth flow state, enabling login CSRF / session fixation (especially dangerous in account-linking).

## Changes

- **Default to host-bound cookie** `__Host-vestibule_session` in `default_options()` (`packages/vestibule_wisp/src/vestibule_wisp.gleam`). `wisp.set_cookie` already emits `Secure`, `Path=/`, and no `Domain`, so the cookie meets the browser `__Host-` requirements out of the box.
- **Validation helper** `is_host_bound_cookie_name/1` so callers can verify a custom `Options.cookie_name` is host-bound.
- **Strong docs** on `Options`, `default_options`, and the package README warning that non-host-bound custom names re-introduce the vulnerability.
- **Changelog** Security fragment for `vestibule_wisp`.

## Why the `__Host-` prefix is sufficient here

A `__Host-` cookie is only accepted by browsers when set with `Secure`, `Path=/`, and **no** `Domain`. Because the cookie has no `Domain`, a sibling subdomain physically cannot overwrite it. `wisp.set_cookie` (via `gleam_http`'s `cookie.defaults`) already sets exactly those attributes, so only the default name needed to change.

## Tests

Added regression tests in `packages/vestibule_wisp/test/vestibule_wisp_test.gleam`:
- `default_cookie_name_is_host_bound_test`
- `is_host_bound_cookie_name_rejects_non_prefixed_test` / `..._accepts_host_prefixed_test`
- `request_phase_sets_host_bound_cookie_test` — asserts the emitted `Set-Cookie` header has the `__Host-vestibule_session` name, `Secure`, `Path=/`, and **no** `Domain` attribute.

Updated existing callback tests to use the new default cookie name.

## Validation

- `gleam build --warnings-as-errors` ✅
- `gleam test` ✅ 20 passed (5 new)
- `gleam format --check src test` ✅

## Note

Changing the default cookie name is a one-time breaking change for any in-flight sessions during deploy; acceptable for a security fix (pre-1.0). Custom cookie names are preserved unchanged.
