### PR TITLE
fix: reject loopback and internal discovered OIDC endpoints (SSRF)

### DIFF
--- a/.changes/unreleased/vestibule-Security-20260613-220900.yaml
+++ b/.changes/unreleased/vestibule-Security-20260613-220900.yaml
@@ -1,0 +1,4 @@
+project: vestibule
+kind: Security
+body: 'OIDC issuer and discovered endpoint URLs (`oidc.new_config`, `oidc.discovery_url`, `oidc.parse_discovery_document`) now require HTTPS and reject loopback, private, link-local, and other non-publicly-routable hosts, closing an SSRF vector where a malicious issuer could publish internal `token_endpoint`/`userinfo_endpoint` values. Redirect URIs still allow `http://localhost` for local development.'
+time: 2026-06-13T22:09:00.000000-07:00

--- a/src/vestibule/oidc.gleam
+++ b/src/vestibule/oidc.gleam
@@ -53,8 +53,11 @@ pub opaque type OidcConfig {
 
 /// Construct a validated OIDC configuration.
 ///
-/// The issuer and endpoint URLs must use HTTPS, except for localhost URLs
-/// which are allowed for local development.
+/// The issuer and endpoint URLs must use HTTPS and target a publicly-routable
+/// host. Loopback (`localhost`, `127.0.0.1`, `[::1]`), private, and link-local
+/// addresses are rejected: these endpoints come from a provider-controlled
+/// discovery document and are called server-side with an `Authorization`
+/// header, so permitting internal hosts would enable SSRF.
 pub fn new_config(
   issuer issuer: String,
   authorization_endpoint authorization_endpoint: String,
@@ -62,10 +65,12 @@ pub fn new_config(
   userinfo_endpoint userinfo_endpoint: String,
   scopes_supported scopes_supported: List(String),
 ) -> Result(OidcConfig, AuthError(e)) {
-  use _ <- result.try(provider_support.require_https(issuer))
-  use _ <- result.try(provider_support.require_https(authorization_endpoint))
-  use _ <- result.try(provider_support.require_https(token_endpoint))
-  use _ <- result.try(provider_support.require_https(userinfo_endpoint))
+  use _ <- result.try(provider_support.require_public_https(issuer))
+  use _ <- result.try(provider_support.require_public_https(
+    authorization_endpoint,
+  ))
+  use _ <- result.try(provider_support.require_public_https(token_endpoint))
+  use _ <- result.try(provider_support.require_public_https(userinfo_endpoint))
 
   Ok(OidcConfig(
     issuer: issuer,
@@ -156,7 +161,8 @@ pub fn fetch_configuration(
 /// `/.well-known/openid-configuration` between the host and issuer path.
 pub fn discovery_url(issuer_url: String) -> Result(String, AuthError(e)) {
   // Security: preserve issuer validation before constructing the fetch URL.
-  use _ <- result.try(provider_support.require_https(issuer_url))
+  // The issuer is provider-controlled, so reject loopback/internal hosts.
+  use _ <- result.try(provider_support.require_public_https(issuer_url))
 
   use issuer <- result.try(
     uri.parse(issuer_url)

--- a/src/vestibule/provider_support.gleam
+++ b/src/vestibule/provider_support.gleam
@@ -4,7 +4,9 @@ import gleam/dynamic/decode
 import gleam/http/request
 import gleam/http/response.{type Response}
 import gleam/httpc
+import gleam/int
 import gleam/json
+import gleam/list
 import gleam/option
 import gleam/result
 import gleam/string
@@ -64,6 +66,158 @@ pub fn require_https(url: String) -> Result(Nil, AuthError(e)) {
           ))
       }
     Error(_) -> Error(error.ConfigError(reason: "Invalid URL: " <> url))
+  }
+}
+
+/// Validate that a URL uses HTTPS *and* targets a publicly-routable host.
+///
+/// Unlike `require_https`, this rejects `http` entirely (no localhost
+/// exception) and also rejects loopback, private, link-local, and other
+/// non-publicly-routable hosts. Use it for values supplied by a provider's
+/// discovery document — such as the OIDC issuer and discovered
+/// token/userinfo endpoints — where an attacker-controlled issuer could
+/// otherwise publish an internal URL and trigger Server-Side Request
+/// Forgery (SSRF) against loopback or internal services.
+///
+/// Returns Ok(Nil) if valid, or a ConfigError describing the issue.
+pub fn require_public_https(url: String) -> Result(Nil, AuthError(e)) {
+  case uri.parse(url) {
+    Ok(parsed) ->
+      case parsed.scheme {
+        option.Some("https") ->
+          case parsed.host {
+            option.Some("") | option.None ->
+              Error(error.ConfigError(
+                reason: "URL must include a host: " <> url,
+              ))
+            option.Some(host) ->
+              case is_non_public_host(host) {
+                True ->
+                  Error(error.ConfigError(
+                    reason: "Endpoint host is not publicly routable (loopback, private, or link-local addresses are not allowed for discovered endpoints): "
+                    <> url,
+                  ))
+                False -> Ok(Nil)
+              }
+          }
+        _ ->
+          Error(error.ConfigError(
+            reason: "HTTPS required for endpoint URL: " <> url,
+          ))
+      }
+    Error(_) -> Error(error.ConfigError(reason: "Invalid URL: " <> url))
+  }
+}
+
+/// Determine whether a URL host refers to a non-publicly-routable target.
+///
+/// Catches the `localhost`/`.local` hostnames plus IPv4 and IPv6 literals in
+/// loopback, private, link-local, shared (CGNAT), and unspecified ranges.
+/// Hostnames that resolve via DNS cannot be classified here and are treated
+/// as public; callers that accept fully untrusted issuers should additionally
+/// restrict resolution at the network layer.
+fn is_non_public_host(host: String) -> Bool {
+  let normalized =
+    host
+    |> string.lowercase
+    |> strip_ipv6_brackets
+
+  case is_blocked_hostname(normalized) {
+    True -> True
+    False ->
+      case parse_ipv4(normalized) {
+        Ok(octets) -> is_non_public_ipv4(octets)
+        Error(_) -> is_non_public_ipv6(normalized)
+      }
+  }
+}
+
+fn strip_ipv6_brackets(host: String) -> String {
+  case string.starts_with(host, "[") && string.ends_with(host, "]") {
+    True -> string.slice(host, 1, string.length(host) - 2)
+    False -> host
+  }
+}
+
+fn is_blocked_hostname(host: String) -> Bool {
+  host == "localhost"
+  || string.ends_with(host, ".localhost")
+  || string.ends_with(host, ".local")
+}
+
+fn parse_ipv4(host: String) -> Result(#(Int, Int, Int, Int), Nil) {
+  case string.split(host, ".") {
+    [a, b, c, d] -> {
+      use a <- result.try(parse_octet(a))
+      use b <- result.try(parse_octet(b))
+      use c <- result.try(parse_octet(c))
+      use d <- result.try(parse_octet(d))
+      Ok(#(a, b, c, d))
+    }
+    _ -> Error(Nil)
+  }
+}
+
+fn parse_octet(segment: String) -> Result(Int, Nil) {
+  case int.parse(segment) {
+    Ok(value) if value >= 0 && value <= 255 -> Ok(value)
+    _ -> Error(Nil)
+  }
+}
+
+fn is_non_public_ipv4(octets: #(Int, Int, Int, Int)) -> Bool {
+  let #(a, b, _c, _d) = octets
+  // 0.0.0.0/8 "this network" / unspecified
+  a == 0
+  // 10.0.0.0/8 private
+  || a == 10
+  // 127.0.0.0/8 loopback
+  || a == 127
+  // 169.254.0.0/16 link-local (incl. cloud metadata 169.254.169.254)
+  || { a == 169 && b == 254 }
+  // 172.16.0.0/12 private
+  || { a == 172 && b >= 16 && b <= 31 }
+  // 192.168.0.0/16 private
+  || { a == 192 && b == 168 }
+  // 100.64.0.0/10 shared address space (CGNAT)
+  || { a == 100 && b >= 64 && b <= 127 }
+  // 224.0.0.0/4 multicast and 240.0.0.0/4 reserved
+  || a >= 224
+}
+
+fn is_non_public_ipv6(host: String) -> Bool {
+  case string.contains(host, ":") {
+    // Not an IPv6 literal; an ordinary DNS hostname we cannot classify here.
+    False -> False
+    True ->
+      // Loopback and unspecified
+      host == "::1"
+      || host == "::"
+      // Unique local addresses fc00::/7 (fc.. / fd..)
+      || string.starts_with(host, "fc")
+      || string.starts_with(host, "fd")
+      // Link-local fe80::/10 (fe8.. / fe9.. / fea.. / feb..)
+      || string.starts_with(host, "fe8")
+      || string.starts_with(host, "fe9")
+      || string.starts_with(host, "fea")
+      || string.starts_with(host, "feb")
+      // IPv4-mapped / IPv4-compatible addresses embedding a non-public IPv4
+      || embeds_non_public_ipv4(host)
+  }
+}
+
+fn embeds_non_public_ipv4(host: String) -> Bool {
+  case list.last(string.split(host, ":")) {
+    Ok(last) ->
+      case string.contains(last, ".") {
+        True ->
+          case parse_ipv4(last) {
+            Ok(octets) -> is_non_public_ipv4(octets)
+            Error(_) -> False
+          }
+        False -> False
+      }
+    Error(_) -> False
   }
 }
 

--- a/test/vestibule/oidc_test.gleam
+++ b/test/vestibule/oidc_test.gleam
@@ -79,13 +79,97 @@ pub fn new_config_rejects_http_userinfo_endpoint_test() {
   Nil
 }
 
-pub fn new_config_allows_localhost_http_endpoints_test() {
+pub fn new_config_rejects_localhost_http_endpoints_test() {
   let result =
     oidc.new_config(
       issuer: "http://localhost",
       authorization_endpoint: "http://localhost/auth",
       token_endpoint: "http://localhost/token",
       userinfo_endpoint: "http://localhost/userinfo",
+      scopes_supported: ["openid", "profile"],
+    )
+
+  let _ = result |> expect.to_be_error()
+  Nil
+}
+
+pub fn new_config_rejects_https_localhost_endpoints_test() {
+  let result =
+    oidc.new_config(
+      issuer: "https://localhost",
+      authorization_endpoint: "https://localhost/auth",
+      token_endpoint: "https://localhost/token",
+      userinfo_endpoint: "https://localhost/userinfo",
+      scopes_supported: ["openid", "profile"],
+    )
+
+  let _ = result |> expect.to_be_error()
+  Nil
+}
+
+pub fn new_config_rejects_loopback_ipv4_endpoint_test() {
+  let result =
+    oidc.new_config(
+      issuer: "https://accounts.example.com",
+      authorization_endpoint: "https://accounts.example.com/auth",
+      token_endpoint: "https://127.0.0.1/token",
+      userinfo_endpoint: "https://accounts.example.com/userinfo",
+      scopes_supported: ["openid", "profile"],
+    )
+
+  let _ = result |> expect.to_be_error()
+  Nil
+}
+
+pub fn new_config_rejects_loopback_ipv6_endpoint_test() {
+  let result =
+    oidc.new_config(
+      issuer: "https://accounts.example.com",
+      authorization_endpoint: "https://accounts.example.com/auth",
+      token_endpoint: "https://accounts.example.com/token",
+      userinfo_endpoint: "https://[::1]/userinfo",
+      scopes_supported: ["openid", "profile"],
+    )
+
+  let _ = result |> expect.to_be_error()
+  Nil
+}
+
+pub fn new_config_rejects_private_network_endpoint_test() {
+  let result =
+    oidc.new_config(
+      issuer: "https://accounts.example.com",
+      authorization_endpoint: "https://192.168.1.10/auth",
+      token_endpoint: "https://accounts.example.com/token",
+      userinfo_endpoint: "https://accounts.example.com/userinfo",
+      scopes_supported: ["openid", "profile"],
+    )
+
+  let _ = result |> expect.to_be_error()
+  Nil
+}
+
+pub fn new_config_rejects_link_local_metadata_endpoint_test() {
+  let result =
+    oidc.new_config(
+      issuer: "https://accounts.example.com",
+      authorization_endpoint: "https://accounts.example.com/auth",
+      token_endpoint: "https://169.254.169.254/token",
+      userinfo_endpoint: "https://accounts.example.com/userinfo",
+      scopes_supported: ["openid", "profile"],
+    )
+
+  let _ = result |> expect.to_be_error()
+  Nil
+}
+
+pub fn new_config_allows_public_https_endpoints_test() {
+  let result =
+    oidc.new_config(
+      issuer: "https://accounts.example.com",
+      authorization_endpoint: "https://accounts.example.com/auth",
+      token_endpoint: "https://accounts.example.com/token",
+      userinfo_endpoint: "https://accounts.example.com/userinfo",
       scopes_supported: ["openid", "profile"],
     )
 
@@ -128,6 +212,42 @@ pub fn parse_discovery_document_rejects_http_endpoint_test() {
   Nil
 }
 
+pub fn parse_discovery_document_rejects_localhost_endpoint_test() {
+  let json =
+    "{\"issuer\":\"https://example.com\",\"authorization_endpoint\":\"https://example.com/auth\",\"token_endpoint\":\"https://localhost/token\",\"userinfo_endpoint\":\"https://example.com/userinfo\"}"
+  let _ =
+    oidc.parse_discovery_document(json)
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn parse_discovery_document_rejects_loopback_ipv4_endpoint_test() {
+  let json =
+    "{\"issuer\":\"https://example.com\",\"authorization_endpoint\":\"https://example.com/auth\",\"token_endpoint\":\"https://example.com/token\",\"userinfo_endpoint\":\"https://127.0.0.1/userinfo\"}"
+  let _ =
+    oidc.parse_discovery_document(json)
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn parse_discovery_document_rejects_loopback_ipv6_endpoint_test() {
+  let json =
+    "{\"issuer\":\"https://example.com\",\"authorization_endpoint\":\"https://[::1]/auth\",\"token_endpoint\":\"https://example.com/token\",\"userinfo_endpoint\":\"https://example.com/userinfo\"}"
+  let _ =
+    oidc.parse_discovery_document(json)
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn parse_discovery_document_rejects_private_network_endpoint_test() {
+  let json =
+    "{\"issuer\":\"https://example.com\",\"authorization_endpoint\":\"https://example.com/auth\",\"token_endpoint\":\"https://10.0.0.5/token\",\"userinfo_endpoint\":\"https://example.com/userinfo\"}"
+  let _ =
+    oidc.parse_discovery_document(json)
+    |> expect.to_be_error()
+  Nil
+}
+
 pub fn parse_discovery_document_invalid_json_test() {
   let json = "not valid json"
   let _ =
@@ -163,6 +283,20 @@ pub fn discovery_url_for_path_issuer_test() {
 pub fn discovery_url_preserves_issuer_validation_test() {
   let _ =
     oidc.discovery_url("http://example.com/tenant")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn discovery_url_rejects_loopback_issuer_test() {
+  let _ =
+    oidc.discovery_url("https://localhost/tenant")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn discovery_url_rejects_loopback_ipv4_issuer_test() {
+  let _ =
+    oidc.discovery_url("https://127.0.0.1")
     |> expect.to_be_error()
   Nil
 }

--- a/test/vestibule/provider_support_test.gleam
+++ b/test/vestibule/provider_support_test.gleam
@@ -72,6 +72,93 @@ pub fn require_https_rejects_https_without_host_test() {
   }
 }
 
+pub fn require_public_https_accepts_public_host_test() {
+  provider_support.require_public_https("https://accounts.example.com/userinfo")
+  |> expect.to_equal(Ok(Nil))
+}
+
+pub fn require_public_https_rejects_http_test() {
+  let _ =
+    provider_support.require_public_https("http://accounts.example.com")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn require_public_https_rejects_localhost_test() {
+  let _ =
+    provider_support.require_public_https("https://localhost/userinfo")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn require_public_https_rejects_loopback_ipv4_test() {
+  let _ =
+    provider_support.require_public_https("https://127.0.0.1/userinfo")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn require_public_https_rejects_loopback_ipv6_test() {
+  let _ =
+    provider_support.require_public_https("https://[::1]/userinfo")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn require_public_https_rejects_private_10_test() {
+  let _ =
+    provider_support.require_public_https("https://10.0.0.5/userinfo")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn require_public_https_rejects_private_192_168_test() {
+  let _ =
+    provider_support.require_public_https("https://192.168.1.1/userinfo")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn require_public_https_rejects_private_172_16_test() {
+  let _ =
+    provider_support.require_public_https("https://172.16.0.1/userinfo")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn require_public_https_rejects_link_local_metadata_test() {
+  let _ =
+    provider_support.require_public_https("https://169.254.169.254/userinfo")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn require_public_https_rejects_cgnat_test() {
+  let _ =
+    provider_support.require_public_https("https://100.64.0.1/userinfo")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn require_public_https_rejects_ula_ipv6_test() {
+  let _ =
+    provider_support.require_public_https("https://[fd00::1]/userinfo")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn require_public_https_rejects_link_local_ipv6_test() {
+  let _ =
+    provider_support.require_public_https("https://[fe80::1]/userinfo")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn require_public_https_allows_public_ipv4_test() {
+  provider_support.require_public_https("https://8.8.8.8/userinfo")
+  |> expect.to_equal(Ok(Nil))
+}
+
 pub fn parse_redirect_uri_rejects_remote_http_test() {
   let result =
     provider_support.parse_redirect_uri("http://example.com/callback")


### PR DESCRIPTION
## Summary

Fixes #56 (security / SSRF). OIDC discovery previously validated discovered endpoints with `provider_support.require_https`, which permits `http://localhost` and `http://127.0.0.1`. That allowance is appropriate for explicit redirect URIs but unsafe for **provider-controlled discovery documents**: a malicious or misconfigured issuer can publish loopback or internal `token_endpoint` / `userinfo_endpoint` values that vestibule then calls server-side with an `Authorization` header — a Server-Side Request Forgery vector against loopback/internal services.

## Change

Split URL validation by trust boundary:

- **Redirect URIs** — unchanged. `parse_redirect_uri` / `require_https` still allow `http://localhost` and `http://127.0.0.1` for local development.
- **OIDC issuer + discovered endpoints** — now validated with the new `provider_support.require_public_https`, which:
  - requires HTTPS (no `http` exception), and
  - rejects non-publicly-routable hosts: `localhost` / `*.localhost` / `*.local`, IPv4 loopback (`127.0.0.0/8`), private (`10/8`, `172.16/12`, `192.168/16`), link-local (`169.254/16`, incl. cloud metadata `169.254.169.254`), shared/CGNAT (`100.64/10`), unspecified (`0.0.0.0/8`), multicast/reserved (`>=224`), and IPv6 loopback (`::1`), unspecified (`::`), ULA (`fc00::/7`), link-local (`fe80::/10`), plus IPv4-mapped forms embedding any of the above.

Applied at the discovery trust boundary in `oidc.new_config` (issuer + all three endpoints) and `oidc.discovery_url` (issuer). `parse_discovery_document` flows through `new_config`, so discovery docs are covered.

> Note: DNS hostnames that resolve to internal IPs cannot be classified statically and are treated as public; callers accepting fully untrusted issuers should additionally restrict resolution at the network layer. This is documented on `require_public_https`.

## Affected code

- `src/vestibule/provider_support.gleam` — new `require_public_https` + host classifiers
- `src/vestibule/oidc.gleam` — `new_config` and `discovery_url` use `require_public_https`

## Tests

Regression tests added for discovery docs and direct validation covering `localhost`, `127.0.0.1`, `[::1]`, private (`10.x`, `192.168.x`, `172.16.x`), link-local metadata (`169.254.169.254`), CGNAT (`100.64.x`), IPv6 ULA (`fd00::1`) and link-local (`fe80::1`); plus positive cases for public HTTPS hosts and IPs. The pre-existing test that asserted localhost OIDC endpoints were allowed was updated to assert rejection.

## Validation

- `gleam format --check src test` — clean
- `gleam check` — clean
- `gleam test` — **180 passed**
