### PR TITLE
fix(google): enforce hosted-domain (hd) restrictions

### DIFF
--- a/.changes/unreleased/vestibule_google-Security-20260612-221100.yaml
+++ b/.changes/unreleased/vestibule_google-Security-20260612-221100.yaml
@@ -1,0 +1,4 @@
+project: vestibule_google
+kind: Security
+body: 'Add `strategy_for_hosted_domain` to enforce a Google Workspace hosted domain. Authentication now fails when the userinfo `hd` claim is missing or does not match the required domain, and the validated `hd` is exposed in `UserResult` extra. Setting `hd` via `config.with_extra_params` remains a UI hint only and is not enforcement.'
+time: 2026-06-12T22:11:00.000000-07:00

--- a/packages/vestibule_google/README.md
+++ b/packages/vestibule_google/README.md
@@ -25,6 +25,29 @@ let cfg =
 
 Google userinfo only populates `UserInfo.email` when `email_verified` is true.
 
+## Hosted-domain (Workspace) enforcement
+
+`strategy()` does **not** restrict sign-in to a Google Workspace domain. Setting
+`hd` via `config.with_extra_params([#("hd", "corp.example")])` only pre-selects
+the account picker — it is a UI hint and **must not** be relied on for
+authorization, because a user can still authenticate with an account outside
+that domain.
+
+To actually restrict sign-in to a single Workspace domain, use
+`strategy_for_hosted_domain`:
+
+```gleam
+let strategy = vestibule_google.strategy_for_hosted_domain("corp.example")
+```
+
+This validates Google's `hd` (hosted-domain) claim from the userinfo response.
+Authentication fails with `error.UserInfoFailed` when the claim is missing
+(e.g. a consumer `gmail.com` account) or does not match `"corp.example"`. The
+validated domain is surfaced under the `"hd"` key of `UserResult`'s `extra`
+dict. The domain is also added to the authorization URL as an account-picker
+hint, but enforcement always happens server-side when the userinfo response is
+validated.
+
 ## Default scopes
 
 `openid email profile`. Override with `config.with_scopes`.

--- a/packages/vestibule_google/src/vestibule_google.gleam
+++ b/packages/vestibule_google/src/vestibule_google.gleam
@@ -5,6 +5,7 @@
 //// `email_verified` before populating `UserInfo.email`.
 
 import gleam/dict
+import gleam/dynamic
 import gleam/dynamic/decode
 import gleam/json
 import gleam/option.{type Option, None, Some}
@@ -28,6 +29,12 @@ import vestibule/strategy.{type Strategy, type UserResult}
 import vestibule/user_info
 
 /// Create a Google authentication strategy.
+///
+/// This strategy does not enforce a Google Workspace hosted domain. If the
+/// userinfo response includes an `hd` claim it is surfaced under the `"hd"`
+/// key of `UserResult`'s `extra` dict, but no domain restriction is applied.
+/// To restrict sign-in to a single Workspace domain, use
+/// `strategy_for_hosted_domain`.
 pub fn strategy() -> Strategy(e) {
   strategy.new(
     provider: "google",
@@ -35,7 +42,34 @@ pub fn strategy() -> Strategy(e) {
     authorize_url: do_authorize_url,
     exchange_code: do_exchange_code,
     refresh_token: do_refresh_token,
-    fetch_user: do_fetch_user,
+    fetch_user: fn(_cfg, exchange) { fetch_user_enforcing(exchange, None) },
+  )
+}
+
+/// Create a Google strategy that enforces a Workspace hosted domain.
+///
+/// Authentication fails unless Google's userinfo response carries an `hd`
+/// (hosted-domain) claim exactly matching `hosted_domain`. A missing or
+/// mismatched `hd` yields `error.UserInfoFailed`. The validated domain is
+/// surfaced under the `"hd"` key of `UserResult`'s `extra` dict.
+///
+/// `hosted_domain` is also added to the authorization URL as an account-picker
+/// hint, but that hint is advisory only — enforcement happens server-side when
+/// the userinfo response is validated. Setting `hd` via
+/// `config.with_extra_params([#("hd", ...)])` is purely a UI hint and must not
+/// be relied on for authorization.
+pub fn strategy_for_hosted_domain(hosted_domain: String) -> Strategy(e) {
+  strategy.new(
+    provider: "google",
+    default_scopes: ["openid", "profile", "email"],
+    authorize_url: fn(cfg, scopes, state) {
+      do_authorize_url_with_hd(cfg, scopes, state, Some(hosted_domain))
+    },
+    exchange_code: do_exchange_code,
+    refresh_token: do_refresh_token,
+    fetch_user: fn(_cfg, exchange) {
+      fetch_user_enforcing(exchange, Some(hosted_domain))
+    },
   )
 }
 
@@ -51,6 +85,21 @@ pub fn parse_token_response(body: String) -> Result(Credentials, AuthError(e)) {
 pub fn parse_user_response(
   body: String,
 ) -> Result(#(String, user_info.UserInfo), AuthError(e)) {
+  parse_user_response_with_hd(body)
+  |> result.map(fn(parsed) {
+    let #(uid, info, _hd) = parsed
+    #(uid, info)
+  })
+}
+
+/// Parse Google userinfo JSON, also extracting the optional `hd`
+/// (hosted-domain) claim used for Workspace domain enforcement.
+///
+/// The third tuple element is the raw `hd` claim, or `None` when the account
+/// is a consumer (gmail.com) account or Google omits the claim.
+pub fn parse_user_response_with_hd(
+  body: String,
+) -> Result(#(String, user_info.UserInfo, Option(String)), AuthError(e)) {
   let decoder = {
     use sub <- decode.field("sub", decode.string)
     use name <- decode.optional_field(
@@ -73,6 +122,7 @@ pub fn parse_user_response(
       None,
       decode.optional(decode.bool),
     )
+    use hd <- decode.optional_field("hd", None, decode.optional(decode.string))
     let verified_email = case email, email_verified {
       Some(addr), Some(True) -> Some(addr)
       _, _ -> None
@@ -87,6 +137,7 @@ pub fn parse_user_response(
         description: None,
         urls: dict.new(),
       ),
+      hd,
     ))
   }
   case json.parse(body, decoder) {
@@ -98,10 +149,52 @@ pub fn parse_user_response(
   }
 }
 
+/// Validate the returned hosted-domain claim against the required domain.
+///
+/// When `required` is `None` the returned claim (if any) passes through
+/// unchanged. When a domain is required, the claim must be present and match
+/// exactly, otherwise authentication fails with `error.UserInfoFailed`. This
+/// is the enforcement primitive behind `strategy_for_hosted_domain`.
+pub fn validate_hosted_domain(
+  required: Option(String),
+  returned: Option(String),
+) -> Result(Option(String), AuthError(e)) {
+  case required, returned {
+    None, _ -> Ok(returned)
+    Some(expected), Some(actual) ->
+      case expected == actual {
+        True -> Ok(Some(actual))
+        False ->
+          Error(error.UserInfoFailed(
+            reason: "Google hosted domain mismatch: expected \""
+            <> expected
+            <> "\" but the account belongs to \""
+            <> actual
+            <> "\"",
+          ))
+      }
+    Some(expected), None ->
+      Error(error.UserInfoFailed(
+        reason: "Google did not return a hosted domain (hd) claim; cannot enforce hosted-domain restriction to \""
+        <> expected
+        <> "\"",
+      ))
+  }
+}
+
 fn do_authorize_url(
   cfg: Config,
   scopes: List(String),
   state: String,
+) -> Result(String, AuthError(e)) {
+  do_authorize_url_with_hd(cfg, scopes, state, None)
+}
+
+fn do_authorize_url_with_hd(
+  cfg: Config,
+  scopes: List(String),
+  state: String,
+  hosted_domain: Option(String),
 ) -> Result(String, AuthError(e)) {
   use site <- result.try(
     uri.parse("https://accounts.google.com")
@@ -118,6 +211,10 @@ fn do_authorize_url(
       secret: config.client_secret(cfg),
       site: site,
     )
+  let extra_params = case hosted_domain {
+    Some(domain) -> [#("hd", domain), ..dict.to_list(config.extra_params(cfg))]
+    None -> dict.to_list(config.extra_params(cfg))
+  }
   let url =
     authorize_uri.build(
       client,
@@ -128,9 +225,7 @@ fn do_authorize_url(
     |> authorize_uri.set_state(state)
     |> authorize_uri.to_code_authorization_uri()
     |> uri.to_string()
-    |> provider_support.append_query_params(
-      dict.to_list(config.extra_params(cfg)),
-    )
+    |> provider_support.append_query_params(extra_params)
   Ok(url)
 }
 
@@ -215,18 +310,28 @@ fn do_refresh_token(
   }
 }
 
-fn do_fetch_user(
-  _cfg: Config,
+fn fetch_user_enforcing(
   exchange: strategy.ExchangeResult,
+  required_hd: Option(String),
 ) -> Result(UserResult, AuthError(e)) {
   use auth_header <- result.try(
     strategy.authorization_header(strategy.exchange_credentials(exchange)),
   )
-  use #(uid, info) <- result.try(provider_support.fetch_json_with_auth(
-    "https://www.googleapis.com/oauth2/v3/userinfo",
-    auth_header,
-    parse_user_response,
-    "Google userinfo",
+  use #(uid, info, returned_hd) <- result.try(
+    provider_support.fetch_json_with_auth(
+      "https://www.googleapis.com/oauth2/v3/userinfo",
+      auth_header,
+      parse_user_response_with_hd,
+      "Google userinfo",
+    ),
+  )
+  use validated_hd <- result.try(validate_hosted_domain(
+    required_hd,
+    returned_hd,
   ))
-  Ok(strategy.user_result(uid: uid, info: info, extra: dict.new()))
+  let extra = case validated_hd {
+    Some(domain) -> dict.from_list([#("hd", dynamic.string(domain))])
+    None -> dict.new()
+  }
+  Ok(strategy.user_result(uid: uid, info: info, extra: extra))
 }

--- a/packages/vestibule_google/test/vestibule_google_test.gleam
+++ b/packages/vestibule_google/test/vestibule_google_test.gleam
@@ -126,3 +126,74 @@ pub fn authorize_url_includes_extra_params_test() {
     strategy.build_authorize_url(strat, conf, ["openid"], "state")
   { string.contains(url, "prompt=consent") } |> expect.to_be_true()
 }
+
+// --- Hosted-domain (hd) enforcement ---
+
+pub fn parse_user_response_with_hd_present_test() {
+  let body =
+    "{\"sub\":\"42\",\"email\":\"jane@corp.example\",\"email_verified\":true,\"hd\":\"corp.example\"}"
+  let assert Ok(#(uid, _info, hd)) =
+    vestibule_google.parse_user_response_with_hd(body)
+  uid |> expect.to_equal("42")
+  hd |> expect.to_equal(Some("corp.example"))
+}
+
+pub fn parse_user_response_with_hd_absent_test() {
+  let body =
+    "{\"sub\":\"42\",\"email\":\"jane@gmail.com\",\"email_verified\":true}"
+  let assert Ok(#(_uid, _info, hd)) =
+    vestibule_google.parse_user_response_with_hd(body)
+  hd |> expect.to_equal(None)
+}
+
+pub fn validate_hosted_domain_match_test() {
+  vestibule_google.validate_hosted_domain(
+    Some("corp.example"),
+    Some("corp.example"),
+  )
+  |> expect.to_be_ok()
+  |> expect.to_equal(Some("corp.example"))
+}
+
+pub fn validate_hosted_domain_mismatch_fails_test() {
+  vestibule_google.validate_hosted_domain(
+    Some("corp.example"),
+    Some("evil.com"),
+  )
+  |> expect.to_be_error()
+  |> fn(err) {
+    case err {
+      error.UserInfoFailed(_) -> Nil
+      _ -> panic as "expected UserInfoFailed for hosted-domain mismatch"
+    }
+  }
+}
+
+pub fn validate_hosted_domain_missing_claim_fails_test() {
+  vestibule_google.validate_hosted_domain(Some("corp.example"), None)
+  |> expect.to_be_error()
+  |> fn(err) {
+    case err {
+      error.UserInfoFailed(_) -> Nil
+      _ -> panic as "expected UserInfoFailed when hd claim is missing"
+    }
+  }
+}
+
+pub fn validate_hosted_domain_not_required_passes_through_test() {
+  vestibule_google.validate_hosted_domain(None, Some("corp.example"))
+  |> expect.to_be_ok()
+  |> expect.to_equal(Some("corp.example"))
+
+  vestibule_google.validate_hosted_domain(None, None)
+  |> expect.to_be_ok()
+  |> expect.to_equal(None)
+}
+
+pub fn strategy_for_hosted_domain_authorize_url_includes_hd_hint_test() {
+  let strat = vestibule_google.strategy_for_hosted_domain("corp.example")
+  let conf = config.new("client-id", "secret", "http://localhost/callback")
+  let assert Ok(url) =
+    strategy.build_authorize_url(strat, conf, ["openid"], "state")
+  { string.contains(url, "hd=corp.example") } |> expect.to_be_true()
+}


### PR DESCRIPTION
## Summary

Closes #57 (security). The Google strategy previously treated the hosted-domain
`hd` parameter as an authorization-screen hint only — `parse_user_response`
ignored the returned `hd` claim and `do_fetch_user` returned `extra: dict.new()`,
so apps relying on `hd=corp.example` for tenant restriction could still accept
users outside that domain (hosted-domain SSO bypass).

## Changes

- **New API `strategy_for_hosted_domain(hosted_domain)`** — validates Google's
  userinfo `hd` claim and fails authentication with `error.UserInfoFailed` when
  the claim is missing (consumer/gmail accounts) or does not match the required
  domain. The domain is also added to the authorization URL as an account-picker
  hint, but enforcement always happens server-side on the userinfo response.
- **Validated `hd` surfaced in `UserResult` extra** under the `"hd"` key (for both
  the plain and hosted-domain strategies, whenever the claim is present).
- **`parse_user_response_with_hd` / `validate_hosted_domain`** exposed as the
  testable enforcement primitives; `parse_user_response` keeps its existing
  signature and behavior.
- **Docs**: README documents the new strategy and explicitly warns that
  `config.with_extra_params([#("hd", ...)])` is a UI hint only, not enforcement.
- Added a `Security` changelog fragment.

## Tests

Added unit tests covering hd extraction (present/absent), validation
(match / mismatch / missing-claim / no-requirement pass-through), and the
authorize-URL hd hint. Full suite: **17 passed, 0 failed**.

## Validation

- `gleam build --warnings-as-errors`: clean
- `gleam format --check src test`: clean
- `gleam test`: 17 passed
