### PR TITLE
fix(core): prevent Credentials debug output from leaking tokens

### DIFF
--- a/.changes/unreleased/vestibule-Security-20260613-051200.yaml
+++ b/.changes/unreleased/vestibule-Security-20260613-051200.yaml
@@ -1,0 +1,4 @@
+project: vestibule
+kind: Security
+body: '`Credentials` access and refresh tokens are now wrapped in an internal secret type, so `string.inspect`, Erlang `~p` formatting, logs, and crash reports redact them even when an `Auth` or `Credentials` value is rendered directly. Public accessors (`credentials.token`, `credentials.refresh_token`) and `credentials.new` are unchanged.'
+time: 2026-06-13T05:12:00.000000000-07:00

--- a/src/vestibule/credentials.gleam
+++ b/src/vestibule/credentials.gleam
@@ -8,16 +8,20 @@
 import gleam/int
 import gleam/option.{type Option, None, Some}
 import gleam/string
+import vestibule/internal/secret.{type Secret}
 
 /// OAuth credentials from the provider.
 ///
 /// Opaque so raw access and refresh tokens are not exposed through pattern
-/// matching or casual field access. Use `new` to construct credentials in
-/// strategies and accessors to read fields when needed.
+/// matching or casual field access. The access and refresh tokens are wrapped
+/// in `Secret`, so `string.inspect`, Erlang `~p` formatting, logs, and crash
+/// reports redact them even when a caller accidentally renders a `Credentials`
+/// (or an `Auth` containing one) directly. Use `new` to construct credentials
+/// in strategies and accessors to read fields when needed.
 pub opaque type Credentials {
   Credentials(
-    token: String,
-    refresh_token: Option(String),
+    token: Secret,
+    refresh_token: Option(Secret),
     token_type: String,
     /// Seconds until the access token expires, as returned by the provider's
     /// `expires_in` field. This is not an absolute timestamp.
@@ -35,8 +39,8 @@ pub fn new(
   scopes scopes: List(String),
 ) -> Credentials {
   Credentials(
-    token: token,
-    refresh_token: refresh_token,
+    token: secret.from_string(token),
+    refresh_token: option.map(refresh_token, secret.from_string),
     token_type: token_type,
     expires_in: expires_in,
     scopes: scopes,
@@ -45,12 +49,12 @@ pub fn new(
 
 /// Return the access token.
 pub fn token(credentials: Credentials) -> String {
-  credentials.token
+  secret.expose(credentials.token)
 }
 
 /// Return the refresh token, when the provider supplied one.
 pub fn refresh_token(credentials: Credentials) -> Option(String) {
-  credentials.refresh_token
+  option.map(credentials.refresh_token, secret.expose)
 }
 
 /// Return the token type, usually `Bearer`.

--- a/src/vestibule/internal/secret.gleam
+++ b/src/vestibule/internal/secret.gleam
@@ -1,0 +1,25 @@
+//// Wrapper for sensitive strings (bearer/refresh/id tokens) that must never
+//// appear in `string.inspect`, Erlang `~p` formatting, logs, or crash reports.
+////
+//// The secret value is captured inside a closure. On the Erlang target a
+//// function is rendered as `//fn() { ... }` and its captured environment is
+//// never shown, so inspecting a value that holds a `Secret` redacts the
+//// underlying string instead of leaking it. Callers must opt in to the raw
+//// value through `expose`.
+
+/// An opaque holder for a sensitive string. Its `inspect`/debug rendering never
+/// reveals the wrapped value.
+pub opaque type Secret {
+  Secret(reveal: fn() -> String)
+}
+
+/// Wrap a sensitive string so it is hidden from inspect/debug output.
+pub fn from_string(value: String) -> Secret {
+  Secret(reveal: fn() { value })
+}
+
+/// Reveal the wrapped string. This is the only way to read the raw value, so
+/// every leak point is explicit at the call site.
+pub fn expose(secret: Secret) -> String {
+  secret.reveal()
+}

--- a/test/vestibule/credentials_redaction_test.gleam
+++ b/test/vestibule/credentials_redaction_test.gleam
@@ -1,0 +1,87 @@
+//// Security regression tests for issue #59: inspect/debug output of
+//// `Credentials` (and an `Auth` that contains one) must never reveal raw
+//// access or refresh token values.
+
+import gleam/dict
+import gleam/option.{None, Some}
+import gleam/string
+import startest/expect
+import vestibule/auth
+import vestibule/credentials
+import vestibule/user_info
+
+const access_token = "ACCESS-TOKEN-SECRET-7f3a"
+
+const refresh_secret = "REFRESH-TOKEN-SECRET-9b21"
+
+fn sample_credentials() -> credentials.Credentials {
+  credentials.new(
+    token: access_token,
+    refresh_token: Some(refresh_secret),
+    token_type: "Bearer",
+    expires_in: Some(3600),
+    scopes: ["email", "profile"],
+  )
+}
+
+pub fn inspect_credentials_does_not_leak_tokens_test() {
+  let rendered = string.inspect(sample_credentials())
+
+  string.contains(rendered, access_token) |> expect.to_be_false()
+  string.contains(rendered, refresh_secret) |> expect.to_be_false()
+}
+
+pub fn inspect_auth_does_not_leak_tokens_test() {
+  let result =
+    auth.Auth(
+      uid: "user-123",
+      provider: "github",
+      info: user_info.UserInfo(
+        name: None,
+        email: None,
+        nickname: None,
+        image: None,
+        description: None,
+        urls: dict.new(),
+      ),
+      credentials: sample_credentials(),
+      extra: dict.new(),
+    )
+
+  let rendered = string.inspect(result)
+
+  string.contains(rendered, access_token) |> expect.to_be_false()
+  string.contains(rendered, refresh_secret) |> expect.to_be_false()
+}
+
+pub fn accessors_still_expose_raw_tokens_test() {
+  let creds = sample_credentials()
+
+  credentials.token(creds) |> expect.to_equal(access_token)
+  credentials.refresh_token(creds) |> expect.to_equal(Some(refresh_secret))
+}
+
+pub fn redacted_never_contains_token_values_test() {
+  let rendered = credentials.redacted(sample_credentials())
+
+  string.contains(rendered, access_token) |> expect.to_be_false()
+  string.contains(rendered, refresh_secret) |> expect.to_be_false()
+  string.contains(rendered, "[REDACTED]") |> expect.to_be_true()
+}
+
+pub fn credentials_without_refresh_token_inspects_cleanly_test() {
+  let creds =
+    credentials.new(
+      token: access_token,
+      refresh_token: None,
+      token_type: "Bearer",
+      expires_in: None,
+      scopes: [],
+    )
+
+  string.inspect(creds)
+  |> string.contains(access_token)
+  |> expect.to_be_false()
+
+  credentials.refresh_token(creds) |> expect.to_equal(None)
+}


### PR DESCRIPTION
## Summary

Fixes #59 (security). `Credentials` stored raw access and refresh tokens as plain `String` fields. Because the runtime value still contained those strings, `string.inspect`, Erlang `~p` formatting, logs, and crash reports of a `Credentials` — or an `Auth` that embeds one — leaked bearer tokens. Opacity hid the fields from pattern matching but did nothing for debug rendering.

## Fix

- New internal module `vestibule/internal/secret` wraps a sensitive string inside a closure. On the Erlang target a function renders as `//fn() { ... }` and never shows its captured environment, so any value holding a `Secret` redacts the underlying string when inspected.
- `Credentials` now stores `token: Secret` and `refresh_token: Option(Secret)`. `credentials.new` wraps the incoming strings; `credentials.token` / `credentials.refresh_token` expose them via `secret.expose`.
- **Public API is unchanged** — `new` still takes `String`/`Option(String)` and the accessors still return them, so no caller (core, sub-packages, examples) needed edits.
- `credentials.redacted` is retained; the new wrapping closes the gap where direct rendering of `Auth`/`Credentials` bypassed it.

## Tests

Added `test/vestibule/credentials_redaction_test.gleam`:
- `string.inspect` of a `Credentials` and of an `Auth` containing it never contains the access or refresh token values.
- Accessors still return the raw tokens.
- `redacted` contains `[REDACTED]` and no token values.
- Credentials with no refresh token inspect cleanly.

These fail against the previous plain-string implementation and pass after the fix.

## Validation

- `gleam test` (root): 160 passed, 0 failed
- `gleam format --check src test`: clean
- `gleam check`: clean
- Sub-packages (`vestibule_apple` 23, `vestibule_google` 10, `vestibule_microsoft` 9, `vestibule_wisp` 16): all pass

Added a `vestibule` Security changelog fragment.
