### PR TITLE
fix(microsoft): add tenant-specific strategy and tenant enforcement

### DIFF
--- a/.changes/unreleased/vestibule_microsoft-Security-20260613-051000.yaml
+++ b/.changes/unreleased/vestibule_microsoft-Security-20260613-051000.yaml
@@ -1,0 +1,4 @@
+project: vestibule_microsoft
+kind: Security
+body: Added `strategy_for_tenant(tenant_id)` for single-tenant apps. It uses tenant-specific Microsoft identity endpoints and verifies the `tid` claim in the returned ID token matches the configured tenant, failing authentication on mismatch. `strategy()` still uses `/common` (multi-tenant, no tenant enforcement) and its tenant-isolation risk is now documented.
+time: 2026-06-13T05:10:00.000000000-07:00

--- a/packages/vestibule_microsoft/README.md
+++ b/packages/vestibule_microsoft/README.md
@@ -50,22 +50,47 @@ The strategy uses Microsoft Graph `/me` for profile data and keeps
 
 ## Tenant behavior
 
-The built-in strategy uses Microsoft Entra ID's `/common` tenant:
+By default, `vestibule_microsoft.strategy()` uses Microsoft Entra ID's `/common`
+tenant:
 
 ```text
 https://login.microsoftonline.com/common/oauth2/v2.0
 ```
 
 This allows both personal Microsoft accounts and work/school accounts from any
-tenant that can consent to your app. It is convenient for general sign-in, but it
-does not restrict authentication to one organization.
+tenant that can consent to your app, and it performs **no** tenant validation. It
+is convenient for general sign-in, but it does **not** restrict authentication to
+one organization. Use it only for explicitly multi-tenant apps.
 
-For tenant-restricted apps, use one of these alternatives:
+### Restricting to a single tenant
 
-- Build an OIDC strategy from tenant-specific endpoints, such as
-  `https://login.microsoftonline.com/<tenant-id>/v2.0`.
-- Write a small custom strategy that uses the same Microsoft Graph `/me` parsing
-  but replaces `/common` with your tenant ID or tenant domain.
+For single-organization apps, use `strategy_for_tenant`:
+
+```gleam
+import vestibule_microsoft
+
+// Pass your tenant's directory (tenant) GUID:
+let strategy =
+  vestibule_microsoft.strategy_for_tenant("72f988bf-86f1-41af-91ab-2d7cd011db47")
+```
+
+This:
+
+- targets the tenant-specific authority endpoints
+  (`https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/...`), so Microsoft
+  only issues tokens for that tenant; and
+- requests the `openid` scope and verifies that the `tid` (tenant id) claim in
+  the returned ID token equals the configured tenant (case-insensitive), failing
+  authentication when the ID token is missing or was issued by a different
+  tenant.
+
+Pass the tenant **GUID** rather than a verified domain
+(e.g. `contoso.onmicrosoft.com`): the `tid` claim is always a GUID, so domain
+values cannot be matched and would reject otherwise-valid logins.
+
+If you need lower-level control, `verify_tenant(expected_tenant, id_token)` and
+`id_token_tenant(id_token)` expose the tenant-claim checks directly.
+
 
 ## Extra authorization parameters
 

--- a/packages/vestibule_microsoft/src/vestibule_microsoft.gleam
+++ b/packages/vestibule_microsoft/src/vestibule_microsoft.gleam
@@ -1,11 +1,24 @@
 //// Microsoft Identity Platform (v2.0) strategy.
 ////
-//// Supports common, organizations, consumers, and per-tenant authorities.
-//// Requests `User.Read` by default. Tokens are
-//// exchanged against `/oauth2/v2.0/token`; user info comes from Microsoft
-//// Graph `/me`.
+//// Requests `User.Read` by default. Tokens are exchanged against
+//// `/oauth2/v2.0/token`; user info comes from Microsoft Graph `/me`.
+////
+//// ## Tenant isolation
+////
+//// `strategy()` uses the `/common` authority, which accepts personal Microsoft
+//// accounts and work/school accounts from **any** Microsoft Entra tenant that
+//// can consent to the app. It does **not** restrict logins to one organization
+//// and performs no tenant validation — use it only for explicitly multi-tenant
+//// apps.
+////
+//// For single-organization apps use `strategy_for_tenant(tenant_id)`. It targets
+//// the tenant-specific authority endpoints and additionally verifies the `tid`
+//// (tenant id) claim in the returned OpenID Connect ID token, failing
+//// authentication when the token was issued by a different tenant.
 
+import gleam/bit_array
 import gleam/dict
+import gleam/dynamic
 import gleam/dynamic/decode
 import gleam/json
 import gleam/option.{type Option, None, Some}
@@ -28,16 +41,65 @@ import vestibule/provider_support
 import vestibule/strategy.{type Strategy, type UserResult}
 import vestibule/user_info.{type UserInfo}
 
-/// Create a Microsoft authentication strategy using /common tenant.
+/// Create a Microsoft authentication strategy using the `/common` authority.
+///
+/// **Security warning:** `/common` accepts personal Microsoft accounts and
+/// work/school accounts from any Microsoft Entra tenant that can consent to the
+/// app, and this strategy performs **no** tenant validation. Use it only for
+/// explicitly multi-tenant apps. For single-organization apps, use
+/// `strategy_for_tenant` so logins are restricted to one tenant and the tenant
+/// is verified against the ID token.
 pub fn strategy() -> Strategy(e) {
+  build_strategy("common", None)
+}
+
+/// Create a Microsoft authentication strategy locked to a single tenant.
+///
+/// `tenant_id` must be the tenant's directory (tenant) **GUID**, e.g.
+/// `"72f988bf-86f1-41af-91ab-2d7cd011db47"`. The strategy uses the
+/// tenant-specific authority endpoints
+/// (`https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0/...`) so
+/// Microsoft itself only issues tokens for that tenant, and additionally
+/// requests the `openid` scope and verifies that the `tid` claim in the
+/// returned ID token equals `tenant_id` (case-insensitive). Authentication
+/// fails if the ID token is missing or was issued by a different tenant.
+///
+/// Pass the tenant GUID rather than a verified domain (e.g.
+/// `contoso.onmicrosoft.com`): the `tid` claim is always a GUID, so domain
+/// values cannot be matched and would reject otherwise-valid logins.
+pub fn strategy_for_tenant(tenant_id: String) -> Strategy(e) {
+  build_strategy(tenant_id, Some(tenant_id))
+}
+
+fn build_strategy(
+  authority: String,
+  expected_tenant: Option(String),
+) -> Strategy(e) {
+  // Tenant-locked strategies need an ID token (`openid` scope) to read `tid`.
+  let default_scopes = case expected_tenant {
+    Some(_) -> ["openid", "User.Read"]
+    None -> ["User.Read"]
+  }
   strategy.new(
     provider: "microsoft",
-    default_scopes: ["User.Read"],
-    authorize_url: do_authorize_url,
-    exchange_code: do_exchange_code,
-    refresh_token: do_refresh_token,
-    fetch_user: do_fetch_user,
+    default_scopes: default_scopes,
+    authorize_url: fn(cfg, scopes, state) {
+      do_authorize_url(authority, cfg, scopes, state)
+    },
+    exchange_code: fn(cfg, code, code_verifier) {
+      do_exchange_code(authority, cfg, code, code_verifier)
+    },
+    refresh_token: fn(cfg, refresh_tok) {
+      do_refresh_token(authority, cfg, refresh_tok)
+    },
+    fetch_user: fn(cfg, exchange) {
+      do_fetch_user(expected_tenant, cfg, exchange)
+    },
   )
+}
+
+fn authority_base(authority: String) -> String {
+  "https://login.microsoftonline.com/" <> authority <> "/oauth2/v2.0"
 }
 
 /// Parse Microsoft token response JSON.
@@ -94,12 +156,13 @@ pub fn parse_user_response(
 }
 
 fn do_authorize_url(
+  authority: String,
   cfg: Config,
   scopes: List(String),
   state: String,
 ) -> Result(String, AuthError(e)) {
   use site <- result.try(
-    uri.parse("https://login.microsoftonline.com/common/oauth2/v2.0")
+    uri.parse(authority_base(authority))
     |> result.map_error(fn(_) {
       error.ConfigError(reason: "Failed to parse Microsoft OAuth base URL")
     }),
@@ -130,12 +193,13 @@ fn do_authorize_url(
 }
 
 fn do_exchange_code(
+  authority: String,
   cfg: Config,
   code: String,
   code_verifier: Option(String),
 ) -> Result(strategy.ExchangeResult, AuthError(e)) {
   use site <- result.try(
-    uri.parse("https://login.microsoftonline.com/common/oauth2/v2.0")
+    uri.parse(authority_base(authority))
     |> result.map_error(fn(_) {
       error.ConfigError(reason: "Failed to parse Microsoft OAuth base URL")
     }),
@@ -161,8 +225,7 @@ fn do_exchange_code(
   case httpc.send(req) {
     Ok(response) -> {
       use body <- result.try(provider_support.check_response_status(response))
-      parse_token_response(body)
-      |> result.map(strategy.exchange_result)
+      parse_exchange_result(body)
     }
     Error(_) ->
       Error(error.NetworkError(
@@ -171,12 +234,50 @@ fn do_exchange_code(
   }
 }
 
+/// Parse a Microsoft token response into an exchange result, capturing the
+/// OpenID Connect `id_token` (when present) as a provider-specific artifact so
+/// tenant-locked strategies can verify the `tid` claim.
+fn parse_exchange_result(
+  body: String,
+) -> Result(strategy.ExchangeResult, AuthError(e)) {
+  use creds <- result.try(parse_token_response(body))
+  Ok(strategy.exchange_result_with_artifacts(
+    creds,
+    id_token_artifacts(parse_id_token(body)),
+  ))
+}
+
+fn parse_id_token(body: String) -> Option(String) {
+  let decoder = {
+    use id_token <- decode.optional_field(
+      "id_token",
+      None,
+      decode.optional(decode.string),
+    )
+    decode.success(id_token)
+  }
+  case json.parse(body, decoder) {
+    Ok(id_token) -> id_token
+    Error(_) -> None
+  }
+}
+
+fn id_token_artifacts(
+  id_token: Option(String),
+) -> dict.Dict(String, dynamic.Dynamic) {
+  case id_token {
+    Some(token) -> dict.from_list([#("id_token", dynamic.string(token))])
+    None -> dict.new()
+  }
+}
+
 fn do_refresh_token(
+  authority: String,
   cfg: Config,
   refresh_tok: String,
 ) -> Result(Credentials, AuthError(e)) {
   use site <- result.try(
-    uri.parse("https://login.microsoftonline.com/common/oauth2/v2.0")
+    uri.parse(authority_base(authority))
     |> result.map_error(fn(_) {
       error.ConfigError(reason: "Failed to parse Microsoft OAuth base URL")
     }),
@@ -211,9 +312,11 @@ fn do_refresh_token(
 }
 
 fn do_fetch_user(
+  expected_tenant: Option(String),
   _cfg: Config,
   exchange: strategy.ExchangeResult,
 ) -> Result(UserResult, AuthError(e)) {
+  use _ <- result.try(enforce_tenant(expected_tenant, exchange))
   use auth_header <- result.try(
     strategy.authorization_header(strategy.exchange_credentials(exchange)),
   )
@@ -224,4 +327,128 @@ fn do_fetch_user(
     "Microsoft Graph",
   ))
   Ok(strategy.user_result(uid: uid, info: info, extra: dict.new()))
+}
+
+/// Enforce that the exchange's ID token was issued by the configured tenant.
+///
+/// Returns `Ok` immediately for multi-tenant (`/common`) strategies. For
+/// tenant-locked strategies, requires an `id_token` artifact and verifies its
+/// `tid` claim against the configured tenant, failing closed when the token is
+/// absent or belongs to a different tenant.
+fn enforce_tenant(
+  expected_tenant: Option(String),
+  exchange: strategy.ExchangeResult,
+) -> Result(Nil, AuthError(e)) {
+  case expected_tenant {
+    None -> Ok(Nil)
+    Some(tenant) -> {
+      use id_token <- result.try(exchange_id_token(exchange))
+      use _ <- result.try(verify_tenant(tenant, id_token))
+      Ok(Nil)
+    }
+  }
+}
+
+fn exchange_id_token(
+  exchange: strategy.ExchangeResult,
+) -> Result(String, AuthError(e)) {
+  let artifacts = strategy.exchange_artifacts(exchange)
+  case dict.get(artifacts, "id_token") {
+    Ok(value) ->
+      case decode.run(value, decode.string) {
+        Ok(token) -> Ok(token)
+        Error(_) ->
+          Error(error.UserInfoFailed(
+            reason: "Microsoft tenant enforcement requires an ID token, "
+            <> "but the token response did not include one. Ensure the "
+            <> "`openid` scope is requested.",
+          ))
+      }
+    Error(_) ->
+      Error(error.UserInfoFailed(
+        reason: "Microsoft tenant enforcement requires an ID token, but the "
+        <> "token response did not include one. Ensure the `openid` scope is "
+        <> "requested.",
+      ))
+  }
+}
+
+/// Verify that a Microsoft OpenID Connect ID token was issued by the expected
+/// tenant.
+///
+/// Reads the `tid` (tenant id) claim from the ID token payload and compares it,
+/// case-insensitively, against `expected_tenant`. Returns the token's `tid` on
+/// success, or an `AuthError` when the claim is missing, malformed, or belongs
+/// to a different tenant.
+///
+/// The ID token is delivered to the client over the back-channel directly from
+/// Microsoft's token endpoint over TLS, so its payload is trusted without a
+/// separate JWKS signature check (OpenID Connect Core 1.0, section 3.1.3.7).
+pub fn verify_tenant(
+  expected_tenant: String,
+  id_token: String,
+) -> Result(String, AuthError(e)) {
+  use tid <- result.try(id_token_tenant(id_token))
+  case string.lowercase(tid) == string.lowercase(expected_tenant) {
+    True -> Ok(tid)
+    False ->
+      Error(error.UserInfoFailed(
+        reason: "Microsoft tenant mismatch: ID token was issued by tenant "
+        <> tid
+        <> " but this strategy is locked to tenant "
+        <> expected_tenant,
+      ))
+  }
+}
+
+/// Extract the `tid` (tenant id) claim from a Microsoft ID token's payload.
+///
+/// Decodes the JWT payload segment (base64url) and reads the `tid` claim. Does
+/// not verify the JWT signature — see `verify_tenant` for the trust rationale.
+pub fn id_token_tenant(id_token: String) -> Result(String, AuthError(e)) {
+  use payload <- result.try(decode_jwt_payload(id_token))
+  let decoder = {
+    use tid <- decode.optional_field(
+      "tid",
+      None,
+      decode.optional(decode.string),
+    )
+    decode.success(tid)
+  }
+  case json.parse(payload, decoder) {
+    Ok(Some(tid)) -> Ok(tid)
+    Ok(None) ->
+      Error(error.UserInfoFailed(
+        reason: "Microsoft ID token is missing the `tid` (tenant id) claim",
+      ))
+    Error(_) ->
+      Error(error.UserInfoFailed(
+        reason: "Failed to parse Microsoft ID token payload",
+      ))
+  }
+}
+
+fn decode_jwt_payload(id_token: String) -> Result(String, AuthError(e)) {
+  case string.split(id_token, ".") {
+    [_header, payload, ..] ->
+      case bit_array.base64_url_decode(payload) {
+        Ok(bits) ->
+          case bit_array.to_string(bits) {
+            Ok(json_payload) -> Ok(json_payload)
+            Error(_) ->
+              Error(error.UserInfoFailed(
+                reason: "Microsoft ID token payload is not valid UTF-8",
+              ))
+          }
+        Error(_) ->
+          Error(error.UserInfoFailed(
+            reason: "Microsoft ID token payload is not valid base64url",
+          ))
+      }
+    _ ->
+      Error(error.UserInfoFailed(
+        reason: "Malformed Microsoft ID token: expected a JWT with a payload "
+        <> "segment",
+      ))
+  }
 }

--- a/packages/vestibule_microsoft/test/vestibule_microsoft_test.gleam
+++ b/packages/vestibule_microsoft/test/vestibule_microsoft_test.gleam
@@ -1,3 +1,4 @@
+import gleam/bit_array
 import gleam/option.{None, Some}
 import gleam/string
 import startest
@@ -9,6 +10,90 @@ import vestibule_microsoft
 
 pub fn main() -> Nil {
   startest.run(startest.default_config())
+}
+
+/// Build a minimal unsigned JWT (header.payload.signature) whose payload is the
+/// given JSON. Only the payload segment is meaningful for tenant verification.
+fn fake_id_token(payload_json: String) -> String {
+  let header = bit_array.base64_url_encode(<<"{\"alg\":\"none\"}":utf8>>, False)
+  let payload = bit_array.base64_url_encode(<<payload_json:utf8>>, False)
+  header <> "." <> payload <> ".sig"
+}
+
+pub fn verify_tenant_match_test() {
+  let token =
+    fake_id_token("{\"tid\":\"72f988bf-86f1-41af-91ab-2d7cd011db47\"}")
+  vestibule_microsoft.verify_tenant(
+    "72f988bf-86f1-41af-91ab-2d7cd011db47",
+    token,
+  )
+  |> expect.to_be_ok()
+  |> expect.to_equal("72f988bf-86f1-41af-91ab-2d7cd011db47")
+}
+
+pub fn verify_tenant_case_insensitive_test() {
+  let token =
+    fake_id_token("{\"tid\":\"72F988BF-86F1-41AF-91AB-2D7CD011DB47\"}")
+  vestibule_microsoft.verify_tenant(
+    "72f988bf-86f1-41af-91ab-2d7cd011db47",
+    token,
+  )
+  |> expect.to_be_ok()
+  Nil
+}
+
+pub fn verify_tenant_mismatch_rejected_test() {
+  let token = fake_id_token("{\"tid\":\"other-tenant-guid\"}")
+  let _ =
+    vestibule_microsoft.verify_tenant("expected-tenant-guid", token)
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn verify_tenant_missing_tid_rejected_test() {
+  let token = fake_id_token("{\"sub\":\"abc\"}")
+  let _ =
+    vestibule_microsoft.verify_tenant("expected-tenant-guid", token)
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn verify_tenant_malformed_token_rejected_test() {
+  let _ =
+    vestibule_microsoft.verify_tenant("expected-tenant-guid", "not-a-jwt")
+    |> expect.to_be_error()
+  Nil
+}
+
+pub fn id_token_tenant_extracts_tid_test() {
+  let token = fake_id_token("{\"tid\":\"abc-123\",\"sub\":\"u1\"}")
+  vestibule_microsoft.id_token_tenant(token)
+  |> expect.to_be_ok()
+  |> expect.to_equal("abc-123")
+}
+
+pub fn strategy_for_tenant_authorize_url_uses_tenant_endpoint_test() {
+  let strat = vestibule_microsoft.strategy_for_tenant("my-tenant-id")
+  let conf = config.new("client-id", "secret", "http://localhost/callback")
+  let assert Ok(url) =
+    strategy.build_authorize_url(strat, conf, ["openid", "User.Read"], "state")
+  { string.contains(url, "login.microsoftonline.com/my-tenant-id/oauth2/v2.0") }
+  |> expect.to_be_true()
+}
+
+pub fn strategy_for_tenant_default_scopes_include_openid_test() {
+  let strat = vestibule_microsoft.strategy_for_tenant("my-tenant-id")
+  strategy.default_scopes(strat)
+  |> expect.to_equal(["openid", "User.Read"])
+}
+
+pub fn common_strategy_authorize_url_uses_common_endpoint_test() {
+  let strat = vestibule_microsoft.strategy()
+  let conf = config.new("client-id", "secret", "http://localhost/callback")
+  let assert Ok(url) =
+    strategy.build_authorize_url(strat, conf, ["User.Read"], "state")
+  { string.contains(url, "login.microsoftonline.com/common/oauth2/v2.0") }
+  |> expect.to_be_true()
 }
 
 pub fn parse_token_response_success_test() {


### PR DESCRIPTION
## Summary

Fixes #58 (security — tenant isolation bypass). The Microsoft strategy hard-coded the `/common` authorization, token, and refresh endpoints and never validated tenant evidence (`tid`/issuer) before returning a `UserResult`. `/common` accepts personal Microsoft accounts and work/school accounts from **any** consenting tenant, so apps that expect "Microsoft login" to mean one organization could be logged into by users from any tenant.

## Changes

- **`strategy_for_tenant(tenant_id)`** (new public API): targets the tenant-specific authority endpoints (`https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0/...`), so Microsoft itself only issues tokens for that tenant. It also:
  - requests the `openid` scope by default (so an ID token is returned),
  - captures the ID token as a provider artifact during code exchange, and
  - verifies the ID token's `tid` (tenant id) claim equals the configured tenant (case-insensitive) in `fetch_user`, **failing closed** when the ID token is missing or was issued by a different tenant.
- **`strategy()`** still uses `/common` for explicitly multi-tenant apps and performs no tenant enforcement; the tenant-isolation risk is now documented in both the module docs and the package README.
- Exposed `verify_tenant(expected_tenant, id_token)` and `id_token_tenant(id_token)` as the testable core of the tenant-claim checks.
- Refactored `do_authorize_url` / `do_exchange_code` / `do_refresh_token` to build endpoints from a parametrized authority instead of a hard-coded `/common`.

### Trust model

The ID token is delivered over the back-channel directly from Microsoft's token endpoint over TLS during code exchange, so its payload is trusted without a separate JWKS signature check (OpenID Connect Core 1.0 §3.1.3.7). Pass the tenant **GUID** (not a verified domain) to `strategy_for_tenant`: the `tid` claim is always a GUID.

## Tests

Added 9 tests covering `verify_tenant` (match, case-insensitive match, mismatch rejected, missing `tid` rejected, malformed token rejected), `id_token_tenant` extraction, tenant-strategy default scopes include `openid`, and tenant vs `/common` authorize-URL endpoints.

## Validation

- `gleam format --check src test` — clean
- `gleam build` — compiles
- `gleam test` — **18 passed**
