### PR TITLE
fix(registry): reject duplicate provider registrations by default

### DIFF
--- a/.changes/unreleased/vestibule-Security-20260613-051936.yaml
+++ b/.changes/unreleased/vestibule-Security-20260613-051936.yaml
@@ -1,0 +1,4 @@
+project: vestibule
+kind: Security
+body: '`registry.register` now rejects a duplicate provider registration with `Error(DuplicateProvider(name))` instead of silently replacing the existing strategy/config, preventing provider impersonation from dynamic or untrusted provider configuration. Trusted callers can use the new `registry.register_or_replace` to intentionally overwrite an entry.'
+time: 2026-06-13T05:19:36.963995+00:00

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ import vestibule_wisp
 import vestibule_wisp/state_store
 
 // Initialize once at startup
-let reg =
+let assert Ok(reg) =
   registry.new()
   |> registry.register(
     github.strategy(),
@@ -151,11 +151,20 @@ Strategies are records of functions — no behaviours, macros, or magic. Each st
 Use a registry to support multiple providers in one app:
 
 ```gleam
-let reg =
+let assert Ok(reg) =
   registry.new()
   |> registry.register(github.strategy(), github_cfg)
+let assert Ok(reg) =
+  reg
   |> registry.register(vestibule_google.strategy(), google_cfg)
 ```
+
+`register` rejects a second registration under an already-registered provider
+name with `Error(DuplicateProvider(name))`, so an untrusted or dynamic provider
+config cannot silently replace a trusted provider. Namespace custom provider
+names (for example `"custom:acme"`) when names come from untrusted input. Use
+`registry.register_or_replace` only when a trusted caller intentionally needs to
+overwrite an existing provider.
 
 Refresh access tokens when a provider issues refresh tokens:
 

--- a/example/src/vestibule_example.gleam
+++ b/example/src/vestibule_example.gleam
@@ -34,11 +34,13 @@ pub fn main() {
   {
     Ok(id), Ok(secret) -> {
       io.println("  Registered provider: github")
-      registry.register(
-        reg,
-        github.strategy(),
-        config.new(id, secret, callback_base <> "/auth/github/callback"),
-      )
+      let assert Ok(reg) =
+        registry.register(
+          reg,
+          github.strategy(),
+          config.new(id, secret, callback_base <> "/auth/github/callback"),
+        )
+      reg
     }
     _, _ -> reg
   }
@@ -49,11 +51,13 @@ pub fn main() {
   {
     Ok(id), Ok(secret) -> {
       io.println("  Registered provider: microsoft")
-      registry.register(
-        reg,
-        vestibule_microsoft.strategy(),
-        config.new(id, secret, callback_base <> "/auth/microsoft/callback"),
-      )
+      let assert Ok(reg) =
+        registry.register(
+          reg,
+          vestibule_microsoft.strategy(),
+          config.new(id, secret, callback_base <> "/auth/microsoft/callback"),
+        )
+      reg
     }
     _, _ -> reg
   }
@@ -64,11 +68,13 @@ pub fn main() {
   {
     Ok(id), Ok(secret) -> {
       io.println("  Registered provider: google")
-      registry.register(
-        reg,
-        vestibule_google.strategy(),
-        config.new(id, secret, callback_base <> "/auth/google/callback"),
-      )
+      let assert Ok(reg) =
+        registry.register(
+          reg,
+          vestibule_google.strategy(),
+          config.new(id, secret, callback_base <> "/auth/google/callback"),
+        )
+      reg
     }
     _, _ -> reg
   }

--- a/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
+++ b/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
@@ -109,7 +109,7 @@ pub fn callback_phase_auth_result_missing_session_cookie_test() {
   let req =
     simulate.request(http.Get, "/auth/test/callback?state=state&code=code")
   let store = state_store.init_named("test_callback_missing_session_cookie")
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(test_strategy(), test_config())
 
@@ -131,7 +131,7 @@ pub fn callback_phase_auth_result_with_options_uses_cookie_name_test() {
   let req =
     simulate.request(http.Get, "/auth/test/callback?state=state&code=code")
     |> simulate.cookie("vestibule_session", session_id, wisp.Signed)
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(test_strategy(), test_config())
 
@@ -155,7 +155,7 @@ pub fn callback_phase_auth_result_malformed_post_body_returns_invalid_params_tes
     simulate.request(http.Post, "/auth/test/callback?state=state&code=code")
     |> simulate.bit_array_body(<<255>>)
     |> simulate.cookie("vestibule_session", session_id, wisp.Signed)
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(test_strategy(), test_config())
 
@@ -172,7 +172,7 @@ pub fn callback_phase_auth_result_missing_state_does_not_consume_session_test() 
   let req_with_state =
     simulate.request(http.Get, "/auth/test/callback?state=state&code=code")
     |> simulate.cookie("vestibule_session", session_id, wisp.Signed)
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(test_strategy(), test_config())
 
@@ -243,7 +243,7 @@ pub fn callback_phase_default_error_response_does_not_render_provider_details_te
   let req =
     simulate.request(http.Get, "/auth/test/callback?state=state&code=code")
     |> simulate.cookie("vestibule_session", session_id, wisp.Signed)
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(leaky_error_strategy(), test_config())
 
@@ -269,7 +269,7 @@ pub fn callback_phase_auth_result_preserves_provider_error_details_test() {
   let req =
     simulate.request(http.Get, "/auth/test/callback?state=state&code=code")
     |> simulate.cookie("vestibule_session", session_id, wisp.Signed)
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(leaky_error_strategy(), test_config())
 

--- a/src/vestibule/registry.gleam
+++ b/src/vestibule/registry.gleam
@@ -13,13 +13,55 @@ pub opaque type Registry(e) {
   Registry(providers: Dict(String, #(Strategy(e), Config)))
 }
 
+/// Errors returned when registering a strategy.
+pub type RegistryError {
+  /// A strategy with this provider name is already registered. Use
+  /// `register_or_replace` if you intend to overwrite the existing entry.
+  DuplicateProvider(name: String)
+}
+
 /// Create an empty registry.
 pub fn new() -> Registry(e) {
   Registry(providers: dict.new())
 }
 
-/// Register a strategy with its config. Provider name is taken from the strategy.
+/// Register a strategy with its config. Provider name is taken from the
+/// strategy.
+///
+/// Registration is rejected with `Error(DuplicateProvider(name))` if a
+/// strategy is already registered under the same provider name. This prevents
+/// a later (possibly untrusted) registration from silently replacing a trusted
+/// provider — which would otherwise enable provider impersonation when account
+/// identity is keyed by `provider + uid`.
+///
+/// When accepting provider names from dynamic or partly untrusted
+/// configuration, namespace custom names (for example `"custom:acme"`) so they
+/// cannot collide with built-in trusted providers. Trusted callers that
+/// genuinely need to overwrite an entry should use `register_or_replace`.
 pub fn register(
+  registry: Registry(e),
+  strategy: Strategy(e),
+  config: Config,
+) -> Result(Registry(e), RegistryError) {
+  let name = strategy.provider(strategy)
+  case dict.has_key(registry.providers, name) {
+    True -> Error(DuplicateProvider(name))
+    False ->
+      Ok(
+        Registry(
+          providers: dict.insert(registry.providers, name, #(strategy, config)),
+        ),
+      )
+  }
+}
+
+/// Register a strategy with its config, replacing any existing strategy
+/// registered under the same provider name.
+///
+/// This is the explicit, trusted-caller counterpart to `register`. Only use it
+/// when the provider name and strategy are fully trusted, since it silently
+/// overwrites a previously registered provider.
+pub fn register_or_replace(
   registry: Registry(e),
   strategy: Strategy(e),
   config: Config,

--- a/test/vestibule/registry_test.gleam
+++ b/test/vestibule/registry_test.gleam
@@ -35,7 +35,7 @@ pub fn new_registry_has_no_providers_test() {
 pub fn register_and_get_provider_test() {
   let strategy = test_strategy("github")
   let cfg = test_config()
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(strategy, cfg)
   let assert Ok(#(s, _c)) = registry.get(reg, "github")
@@ -50,12 +50,67 @@ pub fn get_unknown_provider_returns_error_test() {
 }
 
 pub fn providers_returns_registered_names_test() {
-  let reg =
+  let assert Ok(reg) =
     registry.new()
     |> registry.register(test_strategy("github"), test_config())
+  let assert Ok(reg) =
+    reg
     |> registry.register(test_strategy("microsoft"), test_config())
   let names = registry.providers(reg)
   names |> list.contains("github") |> expect.to_be_true()
   names |> list.contains("microsoft") |> expect.to_be_true()
   names |> list.length |> expect.to_equal(2)
+}
+
+pub fn register_duplicate_provider_is_rejected_test() {
+  let assert Ok(reg) =
+    registry.new()
+    |> registry.register(test_strategy("github"), test_config())
+
+  reg
+  |> registry.register(test_strategy("github"), test_config())
+  |> expect.to_be_error()
+  |> expect.to_equal(registry.DuplicateProvider("github"))
+}
+
+pub fn register_duplicate_does_not_replace_trusted_entry_test() {
+  let trusted_cfg =
+    config.new("trusted_id", "trusted_secret", "https://example.com/callback")
+  let attacker_cfg =
+    config.new(
+      "attacker_id",
+      "attacker_secret",
+      "https://evil.example/callback",
+    )
+
+  let assert Ok(reg) =
+    registry.new()
+    |> registry.register(test_strategy("github"), trusted_cfg)
+
+  // A second registration under the same name must not overwrite the trusted
+  // entry.
+  let _ =
+    reg
+    |> registry.register(test_strategy("github"), attacker_cfg)
+
+  let assert Ok(#(_s, c)) = registry.get(reg, "github")
+  config.client_id(c) |> expect.to_equal("trusted_id")
+}
+
+pub fn register_or_replace_overwrites_existing_test() {
+  let first_cfg =
+    config.new("first_id", "first_secret", "https://example.com/callback")
+  let second_cfg =
+    config.new("second_id", "second_secret", "https://example.com/callback")
+
+  let assert Ok(reg) =
+    registry.new()
+    |> registry.register(test_strategy("github"), first_cfg)
+  let reg =
+    reg
+    |> registry.register_or_replace(test_strategy("github"), second_cfg)
+
+  let assert Ok(#(_s, c)) = registry.get(reg, "github")
+  config.client_id(c) |> expect.to_equal("second_id")
+  registry.providers(reg) |> list.length |> expect.to_equal(1)
 }


### PR DESCRIPTION
## Summary

Fixes #60. `registry.register` used `dict.insert`, so registering a provider under an existing name **silently replaced** the previous strategy/config. In dynamic or partly-untrusted provider configurations a custom strategy could reuse a trusted provider name and overwrite the trusted entry → provider impersonation (account confusion/takeover when identity is keyed by `provider + uid`).

## Changes

- **`src/vestibule/registry.gleam`**
  - `register` now returns `Result(Registry(e), RegistryError)` and rejects a duplicate provider name with `Error(DuplicateProvider(name))` instead of overwriting — duplicate registration is now explicit and safe **by default**.
  - Added `register_or_replace` (returns `Registry(e)`) as the explicit, trusted-caller API for intentional overwrites.
  - Added `RegistryError` / `DuplicateProvider(name)` public type.
  - Documented that untrusted/custom provider names must be namespaced.
- Updated callers: `example/src/vestibule_example.gleam`, `README.md`.
- Updated `packages/vestibule_wisp` tests for the new `Result` signature.

## Tests (regression)

Added to `test/vestibule/registry_test.gleam`:
- `register_duplicate_provider_is_rejected_test` — second register under same name returns `Error(DuplicateProvider("github"))`.
- `register_duplicate_does_not_replace_trusted_entry_test` — the trusted entry survives an attempted overwrite.
- `register_or_replace_overwrites_existing_test` — trusted overwrite path works.

## Validation

- `gleam test` (root): **158 passed, 0 failed**
- `vestibule_wisp` `gleam test`: **16 passed, 0 failed**
- `example` `gleam build`: clean
- `gleam format --check` clean across root, example, and wisp.

## Note

This is an intentional breaking change to `register`'s signature (now returns `Result`), which is the security-correct default requested by the issue title ("reject duplicate provider registrations by default"). Tracked with a `Security` changelog fragment.
