### PR TITLE
ci: align monorepo config with lattice

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -6,33 +6,10 @@ versionHeaderPath: ""
 versionFooterPath: ""
 versionExt: md
 envPrefix: CHANGIE
-
-projectsVersionSeparator: "-"
-
-projects:
-    - label: vestibule
-      key: vestibule
-      changelog: CHANGELOG.md
-    - label: vestibule_apple
-      key: vestibule_apple
-      changelog: packages/vestibule_apple/CHANGELOG.md
-    - label: vestibule_google
-      key: vestibule_google
-      changelog: packages/vestibule_google/CHANGELOG.md
-    - label: vestibule_microsoft
-      key: vestibule_microsoft
-      changelog: packages/vestibule_microsoft/CHANGELOG.md
-    - label: vestibule_wisp
-      key: vestibule_wisp
-      changelog: packages/vestibule_wisp/CHANGELOG.md
-    - label: vestibule_mist
-      key: vestibule_mist
-      changelog: packages/vestibule_mist/CHANGELOG.md
-
 versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
-kindFormat: '#### {{.Kind}}'
+kindFormat: '### {{.Kind}}'
 changeFormat: |-
-    ##### {{(splitn "\n" 2 .Body)._0}}
+    #### {{(splitn "\n" 2 .Body)._0}}
     {{with (splitn "\n" 2 .Body)._1 | default "" | trim}}
     {{.}}
     {{end}}
@@ -40,6 +17,8 @@ body:
     block: true
     minLength: 1
 kinds:
+    - label: Breaking
+      auto: major
     - label: Added
       auto: minor
     - label: Changed
@@ -58,6 +37,7 @@ kinds:
       auto: patch
     - label: Security
       auto: patch
+projectsVersionSeparator: "-"
 newlines:
     afterChangelogHeader: 1
     afterChangelogVersion: 1
@@ -65,3 +45,46 @@ newlines:
     afterVersion: 1
     beforeKind: 1
     endOfVersion: 1
+projects:
+    - label: vestibule
+      key: vestibule
+      changelog: CHANGELOG.md
+      replacements:
+          - path: gleam.toml
+            find: 'version = ".*"'
+            replace: 'version = "{{.VersionNoPrefix}}"'
+    - label: vestibule_apple
+      key: vestibule_apple
+      changelog: packages/vestibule_apple/CHANGELOG.md
+      replacements:
+          - path: packages/vestibule_apple/gleam.toml
+            find: 'version = ".*"'
+            replace: 'version = "{{.VersionNoPrefix}}"'
+    - label: vestibule_google
+      key: vestibule_google
+      changelog: packages/vestibule_google/CHANGELOG.md
+      replacements:
+          - path: packages/vestibule_google/gleam.toml
+            find: 'version = ".*"'
+            replace: 'version = "{{.VersionNoPrefix}}"'
+    - label: vestibule_microsoft
+      key: vestibule_microsoft
+      changelog: packages/vestibule_microsoft/CHANGELOG.md
+      replacements:
+          - path: packages/vestibule_microsoft/gleam.toml
+            find: 'version = ".*"'
+            replace: 'version = "{{.VersionNoPrefix}}"'
+    - label: vestibule_wisp
+      key: vestibule_wisp
+      changelog: packages/vestibule_wisp/CHANGELOG.md
+      replacements:
+          - path: packages/vestibule_wisp/gleam.toml
+            find: 'version = ".*"'
+            replace: 'version = "{{.VersionNoPrefix}}"'
+    - label: vestibule_mist
+      key: vestibule_mist
+      changelog: packages/vestibule_mist/CHANGELOG.md
+      replacements:
+          - path: packages/vestibule_mist/gleam.toml
+            find: 'version = ".*"'
+            replace: 'version = "{{.VersionNoPrefix}}"'

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   auto-tag:
-    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@cc915933b1bf1d3515ce3cf97bb6fac58c10c8ca # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
+    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
     with:
       workspace-file: workspace.toml
       create-release: true

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -9,22 +9,13 @@ permissions:
   contents: write
 
 jobs:
-  workspace:
-    runs-on: ubuntu-latest
-    outputs:
-      projects: ${{ steps.ws.outputs.projects }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-      - name: Read workspace
-        id: ws
-        uses: tylerbutler/actions/read-gleam-workspace@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/read-gleam-workspace@main
-
   auto-tag:
-    needs: workspace
-    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
+    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@cc915933b1bf1d3515ce3cf97bb6fac58c10c8ca # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
     with:
-      projects: ${{ needs.workspace.outputs.projects }}
+      workspace-file: workspace.toml
       create-release: true
+      wait-for-publish: true
+      publish-workflow-name: Publish
     secrets:
       app-id: ${{ secrets.RELEASE_APP_ID }}
       app-private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,38 @@ on:
   workflow_call:
 
 jobs:
-  checks:
-    name: Checks
-    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
+  format:
+    name: Format
+    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
+    with:
+      cache: true
+      format-check: true
+
+  check:
+    name: Check
+    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
+    with:
+      cache: true
+      check: true
+
+  build:
+    name: Build
+    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
     with:
       cache: true
 
-  docs:
-    name: Docs
-    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
+  test:
+    name: Test
+    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
     with:
       cache: true
-      format-check: false
-      check: false
+      run-deps: true
+      test: true
+
+  docs:
+    name: Docs
+    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
+    with:
+      cache: true
       build-strict: false
-      test: false
       docs: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
     with:
       cache: true
+      tools: just
       run-deps: true
       test: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,27 +10,27 @@ on:
 jobs:
   format:
     name: Format
-    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
+    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
     with:
       cache: true
       format-check: true
 
   check:
     name: Check
-    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
+    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
     with:
       cache: true
       check: true
 
   build:
     name: Build
-    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
+    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
     with:
       cache: true
 
   test:
     name: Test
-    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
+    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
     with:
       cache: true
       run-deps: true
@@ -38,7 +38,7 @@ jobs:
 
   docs:
     name: Docs
-    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
+    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
     with:
       cache: true
       build-strict: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft != true
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
         with:
@@ -34,12 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft != true
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: tylerbutler/actions/read-gleam-workspace@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/read-gleam-workspace@main
+      - uses: tylerbutler/actions/read-gleam-workspace@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/read-gleam-workspace@main
         id: workspace
-      - uses: tylerbutler/actions/changie-check@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/changie-check@main
+      - uses: tylerbutler/actions/changie-check@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/changie-check@main
         id: changelog
         with:
           base-sha: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish
 
 # Broad tag pattern so new packages added to workspace.toml are automatically
-# publishable without editing this workflow. Safe because gleam-publish skips
-# versions already on Hex and only publishes packages listed in workspace.toml.
+# publishable without editing this workflow. The workspace reader maps the tag
+# to a known package path before validation or publish runs.
 on:
   push:
     tags:
@@ -10,7 +10,32 @@ on:
 
 jobs:
   test:
-    uses: ./.github/workflows/ci.yml
+    runs-on: ubuntu-latest
+    outputs:
+      package-path: ${{ steps.ws.outputs.tag-package-path }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+      - name: Read workspace
+        id: ws
+        uses: tylerbutler/actions/read-gleam-workspace@f3a3a7d38466a1407c7965872f20e9e8157c11f1 # ratchet:tylerbutler/actions/read-gleam-workspace@main
+        with:
+          tag: ${{ github.ref_name }}
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+
+      - name: Validate tagged package
+        env:
+          PACKAGE: ${{ steps.ws.outputs.tag-package-path }}
+        run: |
+          cd "$PACKAGE"
+          gleam deps download
+          gleam format --check src test
+          gleam check
+          gleam build --warnings-as-errors
+          gleam test
+          gleam docs build
 
   publish:
     needs: test
@@ -18,20 +43,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
-      - name: Read workspace
-        id: ws
-        uses: tylerbutler/actions/read-gleam-workspace@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/read-gleam-workspace@main
-
       - name: Setup environment
         uses: ./.github/actions/setup
 
-      # Publish packages in dependency order (from workspace.toml).
-      # replace-path-deps rewrites `vestibule = { path = "../.." }` to Hex
-      # version ranges derived from the root gleam.toml before publishing.
+      # Publish only the package named by the pushed tag.
+      # replace-path-deps rewrites path dependencies to Hex version ranges
+      # derived from each package's gleam.toml before publishing.
       - name: Publish to Hex.pm
-        uses: tylerbutler/actions/gleam-publish@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/gleam-publish@main
+        uses: tylerbutler/actions/gleam-publish@f3a3a7d38466a1407c7965872f20e9e8157c11f1 # ratchet:tylerbutler/actions/gleam-publish@main
         with:
-          packages: ${{ steps.ws.outputs.packages }}
+          packages: ${{ needs.test.outputs.package-path }}
           replace-path-deps: |
             vestibule:gleam.toml
           hex-api-key: ${{ secrets.HEXPM_API_KEY }}
@@ -47,7 +68,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # ratchet:actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -62,11 +83,7 @@ jobs:
 
       - name: Refresh lockfiles
         run: |
-          # Refresh manifest.toml in root and all sub-packages
-          echo "Refreshing root manifest..."
-          gleam deps download
-
-          for pkg_dir in packages/vestibule_*/; do
+          for pkg_dir in . packages/vestibule_*/; do
             if [ -f "$pkg_dir/gleam.toml" ]; then
               echo "Refreshing $pkg_dir manifest..."
               (cd "$pkg_dir" && gleam deps download)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,11 @@ jobs:
     outputs:
       package-path: ${{ steps.ws.outputs.tag-package-path }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
 
       - name: Read workspace
         id: ws
-        uses: tylerbutler/actions/read-gleam-workspace@f3a3a7d38466a1407c7965872f20e9e8157c11f1 # ratchet:tylerbutler/actions/read-gleam-workspace@main
+        uses: tylerbutler/actions/read-gleam-workspace@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/read-gleam-workspace@main
         with:
           tag: ${{ github.ref_name }}
 
@@ -41,7 +41,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
 
       - name: Setup environment
         uses: ./.github/actions/setup
@@ -50,7 +50,7 @@ jobs:
       # replace-path-deps rewrites path dependencies to Hex version ranges
       # derived from each package's gleam.toml before publishing.
       - name: Publish to Hex.pm
-        uses: tylerbutler/actions/gleam-publish@f3a3a7d38466a1407c7965872f20e9e8157c11f1 # ratchet:tylerbutler/actions/gleam-publish@main
+        uses: tylerbutler/actions/gleam-publish@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/gleam-publish@main
         with:
           packages: ${{ needs.test.outputs.package-path }}
           replace-path-deps: |
@@ -68,12 +68,12 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # ratchet:actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
         with:
           ref: main
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # ratchet:actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -22,24 +22,25 @@ jobs:
 
       - name: Read workspace
         id: ws
-        uses: tylerbutler/actions/read-gleam-workspace@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/read-gleam-workspace@main
+        uses: tylerbutler/actions/read-gleam-workspace@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/read-gleam-workspace@main
 
       - name: Setup environment
         uses: ./.github/actions/setup
 
-      - uses: tylerbutler/actions/changie-release@77f80621309fc7443b628802e08a815d41dd4b47 # ratchet:tylerbutler/actions/changie-release@main
+      - uses: tylerbutler/actions/changie-release@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/changie-release@main
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
-          pr-title-template: 'release {version}'
+          pr-title-template: 'chore(release): {version}'
           projects: ${{ steps.ws.outputs.projects }}
           version-files: |
             ${{ steps.ws.outputs.version-files }}
           post-batch-command: |
             echo "Refreshing lockfiles after version bumps..."
-            gleam deps download
             for d in packages/vestibule_*/; do
-              [ -f "$d/gleam.toml" ] && (cd "$d" && gleam deps download)
+              [ -f "$d/gleam.toml" ] || continue
+              deps=$(grep -E '^vestibule = \{ path =' "$d/gleam.toml" | cut -d= -f1 | xargs || true)
+              [ -n "$deps" ] && (cd "$d" && gleam update $deps)
             done
 
       - name: Summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,23 +11,23 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # ratchet:actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Read workspace
         id: ws
-        uses: tylerbutler/actions/read-gleam-workspace@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/read-gleam-workspace@main
+        uses: tylerbutler/actions/read-gleam-workspace@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/read-gleam-workspace@main
 
       - name: Setup environment
         uses: ./.github/actions/setup
 
-      - uses: tylerbutler/actions/changie-release@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/changie-release@main
+      - uses: tylerbutler/actions/changie-release@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/changie-release@main
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,6 @@
 [tools]
 changie = "latest"
+just = "latest"
 
 [settings]
 legacy_version_file = true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,15 +19,14 @@ gleam run                # Run (if executable)
 
 ```bash
 just deps              # Download dependencies
-just build             # Build project
-just test              # Run tests for root package
-just test-packages     # Run tests for all sub-packages
-just test-all          # Run all tests (root + sub-packages)
+just build             # Build all packages
+just test              # Run tests for all packages
+just test-all          # Alias for all package tests
 just test-pkg <pkg>    # Run tests for a specific sub-package
 just format            # Format code
 just format-check      # Check formatting
-just check             # Type check
-just docs              # Build documentation
+just check             # Type check all packages
+just docs              # Build documentation for all packages
 just ci                # Run all CI checks (format, check, test, build)
 just pr                # Alias for ci (use before PR)
 just main              # Extended checks for main branch
@@ -51,7 +50,8 @@ packages/
 ├── vestibule_apple/                  # Apple Sign In strategy
 ├── vestibule_google/                 # Google OAuth strategy
 ├── vestibule_microsoft/              # Microsoft OAuth strategy
-└── vestibule_wisp/                   # Wisp middleware
+├── vestibule_wisp/                   # Wisp middleware
+└── vestibule_mist/                   # Mist middleware
 example/                              # Example OAuth app
 test/
 └── vestibule_test.gleam
@@ -119,7 +119,7 @@ gleam test
 Managed via `.tool-versions` (source of truth for CI):
 - Erlang 27.2.1
 - Rebar3 3.24.0 (required by vestibule_wisp's transitive deps)
-- Gleam 1.14.0
+- Gleam 1.16.0
 - just 1.38.0
 
 Local development can use `.mise.toml` for flexible versions.
@@ -127,7 +127,7 @@ Local development can use `.mise.toml` for flexible versions.
 ## CI/CD
 
 ### Workflows
-- **ci.yml**: Format check, type check, build, test (root + all sub-packages)
+- **ci.yml**: Split format, type check, build, test, and docs jobs across all packages
 - **pr.yml**: PR title validation (commitlint) and changelog entry check
 - **release.yml**: Multi-project changie-release — batches all packages with changes into a single release PR
 - **auto-tag.yml**: Creates per-package tags (e.g., `vestibule-v0.2.0`, `vestibule_apple-v0.1.1`) when release PR merges
@@ -163,7 +163,7 @@ See `.commitlintrc.json` for configuration.
 ## Changelog
 
 Managed with [changie](https://changie.dev/) using the **projects** feature for multi-package support:
-- **`.changie.yaml`**: Configures 5 projects (vestibule + 4 provider packages) with `projectsVersionSeparator: "-"`
+- **`.changie.yaml`**: Configures 6 projects (vestibule + 5 add-on packages) with `projectsVersionSeparator: "-"`
 - Each package has its own `CHANGELOG.md` (root for vestibule, `packages/<pkg>/CHANGELOG.md` for sub-packages)
 - Fragments go in `.changes/unreleased/`, prefixed by project name
 - Per-project version files stored in `.changes/<project>/v*.md`

--- a/DEV.md
+++ b/DEV.md
@@ -9,7 +9,7 @@ Ensure you have the following installed:
 | Tool | Version | Purpose |
 |------|---------|---------|
 | Erlang/OTP | 27.2.1+ | BEAM runtime |
-| Gleam | 1.14.0+ | Compiler and tooling |
+| Gleam | 1.16.0+ | Compiler and tooling |
 | just | 1.38.0+ | Task runner |
 
 **Recommended:** Use [mise](https://mise.jdx.dev/) or [asdf](https://asdf-vm.com/) with the provided `.tool-versions` file.
@@ -41,10 +41,10 @@ just ci
 ### Daily Development
 
 ```bash
-# Check your code compiles
+# Check every package compiles
 just check
 
-# Run tests
+# Run all package tests
 just test
 
 # Format code (do this before committing)
@@ -90,7 +90,8 @@ just main
 │   ├── vestibule_apple/              # Apple Sign In strategy
 │   ├── vestibule_google/             # Google OAuth strategy
 │   ├── vestibule_microsoft/          # Microsoft OAuth strategy
-│   └── vestibule_wisp/               # Wisp middleware
+│   ├── vestibule_wisp/               # Wisp middleware
+│   └── vestibule_mist/               # Mist middleware
 ├── example/                          # Example OAuth app
 ├── .github/
 │   ├── actions/setup/                # Reusable CI setup
@@ -159,10 +160,10 @@ pub fn parse(input: String) -> Result(Value, ParseError)
 ### Running Tests
 
 ```bash
-# Run root-package tests
+# Run all package tests
 just test
 
-# Run root + package tests
+# Backwards-compatible alias for all package tests
 just test-all
 ```
 
@@ -218,8 +219,8 @@ test: add edge case tests for unicode handling
 ## Release Process
 
 This is a multi-package repository. Each package (`vestibule`, `vestibule_apple`,
-`vestibule_google`, `vestibule_microsoft`, `vestibule_wisp`) is independently
-versioned and published to Hex.pm.
+`vestibule_google`, `vestibule_microsoft`, `vestibule_wisp`, and
+`vestibule_mist`) is independently versioned and published to Hex.pm.
 
 ### Adding Changelog Entries
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ See the [strategy authoring guide](docs/guides/writing-a-custom-strategy.md) for
 
 ## Target
 
-Erlang (BEAM) runtime. Core types can cross-compile to JavaScript, but OAuth callbacks require a server.
+Erlang (BEAM) runtime. The current packages are validated on the Erlang target only.
 
 ## License
 

--- a/justfile
+++ b/justfile
@@ -1,4 +1,7 @@
-# Gleam Project Tasks
+# Vestibule Monorepo Tasks
+#
+# Packages are built/tested in dependency order:
+#   vestibule → provider packages and middleware packages
 
 set dotenv-load := true
 set dotenv-path := "example/.env"
@@ -8,90 +11,116 @@ alias b := build
 alias t := test
 alias f := format
 alias l := lint
-alias c := clean
+alias c := check
 alias d := docs
 alias cl := change
+alias cp := change-pkg
 
 default:
     @just --list
 
+# Packages in topological (dependency) order. "." is the root vestibule package.
+packages := ". vestibule_apple vestibule_google vestibule_microsoft vestibule_wisp vestibule_mist"
+
 # === DEPENDENCIES ===
 
-# Download project dependencies
+# Download dependencies for all packages
 deps:
-    gleam deps download
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for pkg in {{ packages }}; do
+        dir="packages/$pkg"
+        if [ "$pkg" = "." ]; then dir="."; fi
+        echo "==> $pkg: downloading deps"
+        ( cd "$dir" && gleam deps download )
+    done
 
 # === BUILD ===
 
-# Build project (Erlang target)
+# Build all packages (Erlang target)
 build:
-    gleam build
-
-# Build with warnings as errors
-build-strict:
-    gleam build --warnings-as-errors
-
-# Build sub-packages with warnings as errors
-build-strict-packages:
-    scripts/build-strict-packages.sh
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for pkg in {{ packages }}; do
+        dir="packages/$pkg"
+        if [ "$pkg" = "." ]; then dir="."; fi
+        echo "==> $pkg: building"
+        ( cd "$dir" && gleam build )
+    done
 
 # Build all packages with warnings as errors
-build-strict-all: build-strict build-strict-packages
+build-strict:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for pkg in {{ packages }}; do
+        dir="packages/$pkg"
+        if [ "$pkg" = "." ]; then dir="."; fi
+        echo "==> $pkg: building (strict)"
+        ( cd "$dir" && gleam build --warnings-as-errors )
+    done
 
 # === TESTING ===
 
-# Run tests for root package
+# Run tests for all packages (Erlang target)
 test:
-    gleam test
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for pkg in {{ packages }}; do
+        dir="packages/$pkg"
+        if [ "$pkg" = "." ]; then dir="."; fi
+        echo "==> $pkg: testing (erlang)"
+        ( cd "$dir" && gleam test )
+    done
 
-# Run tests for all sub-packages
-test-packages:
-    scripts/test-packages.sh
-
-# Run all tests (root + sub-packages)
-test-all: test test-packages
+# Backwards-compatible alias for all tests
+test-all: test
 
 # Run tests for a specific sub-package
 test-pkg pkg:
-    cd packages/{{pkg}} && gleam test
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "{{ pkg }}" = "." ]; then
+        gleam test
+    else
+        cd packages/{{ pkg }} && gleam test
+    fi
 
 # === CODE QUALITY ===
 
-# Format source code
+# Format source code in all packages
 format:
-    gleam format src test
-
-# Format sub-package source code
-format-packages:
-    scripts/format-packages.sh
-
-# Format all packages
-format-all: format format-packages
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for pkg in {{ packages }}; do
+        dir="packages/$pkg"
+        if [ "$pkg" = "." ]; then dir="."; fi
+        ( cd "$dir" && gleam format src test )
+    done
 
 # Check formatting without changes
 format-check:
-    gleam format --check src test
-
-# Check formatting for sub-packages
-format-check-packages:
-    scripts/format-check-packages.sh
-
-# Check formatting for all packages
-format-check-all: format-check format-check-packages
-
-# Type check without building
-check: lint
-
-# Run linter/static checks
-lint:
-    gleam check
-
-# Type check sub-packages
-check-packages:
-    scripts/check-packages.sh
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for pkg in {{ packages }}; do
+        dir="packages/$pkg"
+        if [ "$pkg" = "." ]; then dir="."; fi
+        echo "==> $pkg: format check"
+        ( cd "$dir" && gleam format --check src test )
+    done
 
 # Type check all packages
-check-all: check check-packages
+check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for pkg in {{ packages }}; do
+        dir="packages/$pkg"
+        if [ "$pkg" = "." ]; then dir="."; fi
+        echo "==> $pkg: type check"
+        ( cd "$dir" && gleam check )
+    done
+
+# Backwards-compatible alias for static checks
+lint: check
 
 # === EXAMPLE APP ===
 
@@ -101,16 +130,16 @@ serve:
 
 # === DOCUMENTATION ===
 
-# Build documentation
-docs:
-    gleam docs build
-
-# Build documentation for sub-packages
-docs-packages:
-    scripts/docs-packages.sh
-
 # Build documentation for all packages
-docs-all: docs docs-packages
+docs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for pkg in {{ packages }}; do
+        dir="packages/$pkg"
+        if [ "$pkg" = "." ]; then dir="."; fi
+        echo "==> $pkg: building docs"
+        ( cd "$dir" && gleam docs build )
+    done
 
 # === CHANGELOG ===
 
@@ -126,79 +155,42 @@ change-pkg pkg:
 changelog-preview pkg:
     changie batch auto --project {{pkg}} --dry-run
 
-# Generate CHANGELOG.md
-changelog:
-    changie merge
+# Generate CHANGELOG.md for a project
+changelog pkg:
+    changie merge --project {{pkg}}
 
 # === MAINTENANCE ===
 
-# Remove build artifacts
+# Remove build artifacts from all packages
 clean:
-    rm -rf build
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for pkg in {{ packages }}; do
+        dir="packages/$pkg"
+        if [ "$pkg" = "." ]; then dir="."; fi
+        rm -rf "$dir/build"
+    done
+    rm -rf example/build
+
+# === PER-PACKAGE TARGETS ===
+
+# Build a single package: just build-pkg vestibule_google
+build-pkg pkg:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "{{ pkg }}" = "." ]; then
+        gleam build
+    else
+        cd packages/{{ pkg }} && gleam build
+    fi
 
 # === CI ===
 
-# Run all CI checks (format, check, root + package tests, build)
-ci: format-check lint test-all build-strict
-
-# Run all CI checks across all packages
-ci-all: format-check-all check-all test-all build-strict-all
+# Run all CI checks (format, check, test, build strict)
+ci: format-check check test build-strict
 
 # Alias for PR checks
 alias pr := ci
 
 # Run extended checks for main branch
-main: ci-all docs-all
-
-# =============================================================================
-# MULTI-TARGET SUPPORT (Uncomment if targeting JavaScript)
-# =============================================================================
-
-# # Build for JavaScript target
-# build-js:
-#     gleam build --target javascript
-
-# # Build all targets
-# build-all: build build-js
-
-# # Build JavaScript with warnings as errors
-# build-strict-js:
-#     gleam build --target javascript --warnings-as-errors
-
-# # Build all targets strictly
-# build-strict-all: build-strict build-strict-js
-
-# # Test on Erlang target
-# test-erlang:
-#     gleam test
-
-# # Test on JavaScript target
-# test-js:
-#     gleam test --target javascript
-
-# # Test on all targets
-# test-all: test-erlang test-js
-
-# =============================================================================
-# JAVASCRIPT INTEGRATION TESTS (Uncomment if needed)
-# =============================================================================
-
-# # Run integration tests with Node.js
-# test-integration-node: build-js
-#     node --test test/integration/test_runner.mjs
-
-# # Run integration tests with Deno
-# test-integration-deno: build-js
-#     deno test --allow-read --allow-env test/integration/test_runner.mjs
-
-# # Run integration tests with Bun
-# test-integration-bun: build-js
-#     bun test test/integration/test_runner.mjs
-
-# =============================================================================
-# COVERAGE (Uncomment if needed)
-# =============================================================================
-
-# # Run tests with coverage (requires setup - see README)
-# coverage:
-#     @echo "Coverage requires additional setup. See README.md"
+main: ci docs

--- a/scripts/verify-monorepo-config.sh
+++ b/scripts/verify-monorepo-config.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+failures=0
+
+check() {
+    local description=$1
+    shift
+
+    if "$@"; then
+        printf 'ok - %s\n' "$description"
+    else
+        printf 'not ok - %s\n' "$description"
+        failures=$((failures + 1))
+    fi
+}
+
+contains() {
+    local file=$1
+    local pattern=$2
+    grep -Fq -- "$pattern" "$file"
+}
+
+matches() {
+    local file=$1
+    local pattern=$2
+    grep -Eq -- "$pattern" "$file"
+}
+
+not_contains() {
+    local file=$1
+    local pattern=$2
+    ! grep -Fq -- "$pattern" "$file"
+}
+
+check "workspace includes root and vestibule packages" \
+    contains workspace.toml 'members = [".", "packages/vestibule_*"]'
+check "workspace has no package excludes" \
+    not_contains workspace.toml "exclude = ["
+
+check "justfile uses an explicit topological package list" \
+    contains justfile 'packages := ". vestibule_apple vestibule_google vestibule_microsoft vestibule_wisp vestibule_mist"'
+check "justfile loops over packages for deps" \
+    matches justfile 'for pkg in \{\{ packages \}\}; do[[:space:]]*$'
+check "justfile no longer delegates package checks to scripts" \
+    not_contains justfile "scripts/check-packages.sh"
+check "justfile no longer delegates package tests to scripts" \
+    not_contains justfile "scripts/test-packages.sh"
+check "justfile omits JavaScript tests while Vestibule is Erlang-only" \
+    not_contains justfile "test-js:"
+check "justfile CI matches lattice shape" \
+    contains justfile "ci: format-check check test build-strict"
+
+for job in format check build test docs; do
+    check "CI has $job job" \
+        matches .github/workflows/ci.yml "^  $job:"
+done
+check "CI has no grouped checks job" \
+    not_contains .github/workflows/ci.yml "  checks:"
+check "CI omits JavaScript tests while Vestibule is Erlang-only" \
+    not_contains .github/workflows/ci.yml "test-js"
+
+check "release PR title matches lattice" \
+    contains .github/workflows/release.yml "pr-title-template: 'chore(release): {version}'"
+check "release updates local vestibule path deps after version bumps" \
+    contains .github/workflows/release.yml "gleam update \$deps"
+check "release does not refresh every lockfile unconditionally" \
+    not_contains .github/workflows/release.yml "gleam deps download"
+
+check "auto-tag uses workspace-file input" \
+    contains .github/workflows/auto-tag.yml "workspace-file: workspace.toml"
+check "auto-tag waits for publish" \
+    contains .github/workflows/auto-tag.yml "wait-for-publish: true"
+check "auto-tag identifies publish workflow" \
+    contains .github/workflows/auto-tag.yml "publish-workflow-name: Publish"
+
+check "publish validates tagged package only" \
+    contains .github/workflows/publish.yml 'PACKAGE: ${{ steps.ws.outputs.tag-package-path }}'
+check "publish reads tag metadata from workspace" \
+    contains .github/workflows/publish.yml 'tag: ${{ github.ref_name }}'
+check "publish exposes tagged package path" \
+    contains .github/workflows/publish.yml 'package-path: ${{ steps.ws.outputs.tag-package-path }}'
+check "publish omits JavaScript tests while Vestibule is Erlang-only" \
+    not_contains .github/workflows/publish.yml "gleam test --target javascript"
+check "publish publishes tagged package only" \
+    contains .github/workflows/publish.yml 'packages: ${{ needs.test.outputs.package-path }}'
+check "publish rewrites vestibule path dependency" \
+    contains .github/workflows/publish.yml "vestibule:gleam.toml"
+
+for path in \
+    gleam.toml \
+    packages/vestibule_apple/gleam.toml \
+    packages/vestibule_google/gleam.toml \
+    packages/vestibule_microsoft/gleam.toml \
+    packages/vestibule_wisp/gleam.toml \
+    packages/vestibule_mist/gleam.toml
+do
+    check "changie updates $path" \
+        contains .changie.yaml "path: $path"
+done
+
+if [ "$failures" -ne 0 ]; then
+    printf '\n%s monorepo config check(s) failed.\n' "$failures"
+    exit 1
+fi
+
+printf '\nAll monorepo config checks passed.\n'

--- a/workspace.toml
+++ b/workspace.toml
@@ -1,8 +1,2 @@
 [workspace]
 members = [".", "packages/vestibule_*"]
-exclude = [
-  "packages/vestibule_apple",
-  "packages/vestibule_google",
-  "packages/vestibule_microsoft",
-  "packages/vestibule_wisp",
-]


### PR DESCRIPTION
## Summary
- Make all Vestibule packages workspace-managed and drive local tasks from an explicit topological package loop.
- Split CI into Lattice-style format, check, build, test, and docs jobs.
- Align release, auto-tag, publish, and changie config with per-package release behavior.

## Test Plan
- [x] bash scripts/verify-monorepo-config.sh
- [x] just ci
- [x] just docs
- [x] git diff --check

Note: JavaScript target checks are intentionally omitted because `vestibule/state_store.gleam` uses Erlang-only externals today.