### PR TITLE
ci: grant auto-tag actions read permission

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
 
 permissions:
+  actions: read
   contents: write
 
 jobs:


### PR DESCRIPTION
## Summary
- Grant actions: read to the Auto-tag release workflow caller so it can invoke the reusable auto-tag workflow.

## Validation
- git diff --check