### PR TITLE
fix(website): publish Astro dist on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+base = "website"
+command = "pnpm build"
+publish = "dist"


### PR DESCRIPTION
## Summary
- configure Netlify to build from the website directory
- publish Astro's generated dist output

## Test
- pnpm build