### PR TITLE
chore(lint): enable glinter with strict warnings and clean up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,14 @@ jobs:
       cache: true
       check: true
 
+  lint:
+    name: Lint
+    uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
+    with:
+      cache: true
+      run-deps: true
+      custom-command: gleam run -m glinter
+
   build:
     name: Build
     uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@1761c18aa4583d74916e1a53f2a106d1d70d72a8 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
     with:
       cache: true
+      tools: just
       run-deps: true
       custom-command: gleam run -m glinter
 

--- a/example/gleam.toml
+++ b/example/gleam.toml
@@ -23,3 +23,18 @@ ref = "0f49223187fe57f646642ad0be12468c400401a2"
 
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+[tools.glinter]
+# Strict lint: any warning fails the build. glinter only supports this
+# globally (no per-rule error severity), so label_possible is turned off
+# below to keep intentional unlabelled subject/pipe first-args from failing.
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Argument labels are encouraged but not enforced: many functions intentionally
+# leave their subject/pipe-receiver first arg unlabelled.
+label_possible = "off"
+# main() validates startup config and crashes on misconfiguration, which is
+# the legitimate crash-on-startup pattern for an application entry point.
+avoid_panic = "off"

--- a/example/manifest.toml
+++ b/example/manifest.toml
@@ -9,6 +9,7 @@ packages = [
   { name = "envoy", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "850DA9D29D2E5987735872A2B5C81035146D7FE19EFC486129E44440D03FD832" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
@@ -22,7 +23,9 @@ packages = [
   { name = "gleam_stdlib", version = "0.69.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "AAB0962BEBFAA67A2FBEE9EEE218B057756808DC9AF77430F5182C6115B3A315" },
   { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "glisten", version = "8.0.3", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "86B838196592D9EBDE7A1D2369AE3A51E568F7DD2D168706C463C42D17B95312" },
   { name = "glow_auth", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_json", "gleam_stdlib", "gleam_time"], otp_app = "glow_auth", source = "hex", outer_checksum = "BCF868EC62BA7431A38D267EF00CFD846E28C6EAA5B349CB3099EAC013C6C7CB" },
   { name = "gramps", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "8B7195978FBFD30B43DF791A8A272041B81E45D245314D7A41FC57237AA882A0" },
@@ -35,6 +38,7 @@ packages = [
   { name = "platform", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "platform", source = "hex", outer_checksum = "8339420A95AD89AAC0F82F4C3DB8DD401041742D6C3F46132A8739F6AEB75391" },
   { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
   { name = "tom", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "90791DA4AACE637E30081FE77049B8DB850FBC8CACC31515376BCC4E59BE1DD2" },
@@ -52,6 +56,7 @@ envoy = { version = ">= 1.1.0 and < 2.0.0" }
 gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.0.0 and < 5.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 houdini = { version = ">= 1.2.0 and < 2.0.0" }
 mist = { version = ">= 4.0.0 and < 6.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }

--- a/example/src/html.gleam
+++ b/example/src/html.gleam
@@ -8,6 +8,7 @@
 //// image-URL scheme allowlist below is custom because no escaping library
 //// validates URL schemes.
 
+import gleam/bool
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import houdini
@@ -20,8 +21,9 @@ import houdini
 /// Returns the attribute-escaped URL when safe, or `None` when the scheme is
 /// not allowlisted.
 pub fn safe_image_url(url: String) -> Option(String) {
-  case string.starts_with(string.lowercase(url), "https://") {
-    True -> Some(houdini.escape(url))
-    False -> None
-  }
+  use <- bool.guard(
+    when: !string.starts_with(string.lowercase(url), "https://"),
+    return: None,
+  )
+  Some(houdini.escape(url))
 }

--- a/example/src/router.gleam
+++ b/example/src/router.gleam
@@ -21,7 +21,12 @@ pub fn handle_request(req: Request, ctx: Context(e)) -> Response {
 
     // Phase 1: Redirect to provider
     ["auth", provider], http.Get ->
-      vestibule_wisp.request_phase(req, ctx.registry, provider, ctx.state_store)
+      vestibule_wisp.request_phase(
+        req,
+        reg: ctx.registry,
+        provider: provider,
+        state_store: ctx.state_store,
+      )
 
     // Phase 2: Handle callback (GET for most providers, POST for Apple form_post)
     ["auth", provider, "callback"], http.Get
@@ -29,10 +34,10 @@ pub fn handle_request(req: Request, ctx: Context(e)) -> Response {
     ->
       vestibule_wisp.callback_phase(
         req,
-        ctx.registry,
-        provider,
-        ctx.state_store,
-        fn(auth) { pages.success(auth) },
+        reg: ctx.registry,
+        provider: provider,
+        state_store: ctx.state_store,
+        on_success: fn(auth) { pages.success(auth) },
       )
 
     // Everything else

--- a/example/src/vestibule_example.gleam
+++ b/example/src/vestibule_example.gleam
@@ -15,7 +15,7 @@ import vestibule_google
 import vestibule_microsoft
 import vestibule/state_store
 
-pub fn main() {
+pub fn main() -> Nil {
   let port =
     envoy.get("PORT")
     |> result.try(int.parse)
@@ -37,8 +37,12 @@ pub fn main() {
       let assert Ok(reg) =
         registry.register(
           reg,
-          vestibule_github.strategy(),
-          config.new(id, secret, callback_base <> "/auth/github/callback"),
+          strategy: vestibule_github.strategy(),
+          config: config.new(
+            client_id: id,
+            client_secret: secret,
+            redirect_uri: callback_base <> "/auth/github/callback",
+          ),
         )
       reg
     }
@@ -54,8 +58,12 @@ pub fn main() {
       let assert Ok(reg) =
         registry.register(
           reg,
-          vestibule_microsoft.strategy(),
-          config.new(id, secret, callback_base <> "/auth/microsoft/callback"),
+          strategy: vestibule_microsoft.strategy(),
+          config: config.new(
+            client_id: id,
+            client_secret: secret,
+            redirect_uri: callback_base <> "/auth/microsoft/callback",
+          ),
         )
       reg
     }
@@ -71,8 +79,12 @@ pub fn main() {
       let assert Ok(reg) =
         registry.register(
           reg,
-          vestibule_google.strategy(),
-          config.new(id, secret, callback_base <> "/auth/google/callback"),
+          strategy: vestibule_google.strategy(),
+          config: config.new(
+            client_id: id,
+            client_secret: secret,
+            redirect_uri: callback_base <> "/auth/google/callback",
+          ),
         )
       reg
     }

--- a/gleam.toml
+++ b/gleam.toml
@@ -17,3 +17,33 @@ gleam_time = ">= 1.7.0 and < 2.0.0"
 
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+[tools.glinter]
+# Strict lint: any warning fails the build. glinter only supports this
+# globally (no per-rule error severity), so label_possible is turned off
+# below to keep intentional unlabelled subject/pipe first-args from failing.
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Argument labels are encouraged but not enforced: many functions intentionally
+# leave their subject/pipe-receiver first arg unlabelled.
+label_possible = "off"
+# Public library API: these functions are part of vestibule's published surface
+# and are intentionally exported for external consumers, even when unused within
+# the monorepo.
+unused_exports = "off"
+# Deliberate crash-on-startup pattern: init/store-style functions assert on
+# known-good values during one-time VM setup. Result-returning try_* variants are
+# provided for callers that need to handle failure.
+assert_ok_pattern = "off"
+# By design, low-level errors (uri.parse, request.to, httpc — often Nil/opaque)
+# are mapped into descriptive domain AuthError variants; the source errors carry
+# no additional context worth wrapping.
+error_context_lost = "off"
+# Intentional best-effort / fallback control flow (e.g. URL parse fallbacks)
+# where discarding the error is the desired behavior.
+thrown_away_error = "off"
+# Private @external FFI declarations return String reasons that are immediately
+# mapped to the typed StateStoreError; the stringly-typed boundary is internal.
+stringly_typed_error = "off"

--- a/justfile
+++ b/justfile
@@ -119,8 +119,30 @@ check:
         ( cd "$dir" && gleam check )
     done
 
-# Backwards-compatible alias for static checks
-lint: check
+# Lint all packages with glinter
+lint:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for pkg in {{ packages }}; do
+        dir="packages/$pkg"
+        if [ "$pkg" = "." ]; then dir="."; fi
+        echo "==> $pkg: linting"
+        ( cd "$dir" && gleam run -m glinter )
+    done
+    echo "==> example: linting"
+    ( cd example && gleam run -m glinter )
+
+# Lint a single package: just lint-pkg vestibule_google
+lint-pkg pkg:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "{{ pkg }}" = "." ]; then
+        gleam run -m glinter
+    elif [ "{{ pkg }}" = "example" ]; then
+        cd example && gleam run -m glinter
+    else
+        cd packages/{{ pkg }} && gleam run -m glinter
+    fi
 
 # === EXAMPLE APP ===
 
@@ -198,8 +220,8 @@ build-pkg pkg:
 
 # === CI ===
 
-# Run all CI checks (format, check, test, build strict)
-ci: format-check check test build-strict
+# Run all CI checks (format, lint, check, test, build strict)
+ci: format-check lint check test build-strict
 
 # Alias for PR checks
 alias pr := ci

--- a/manifest.toml
+++ b/manifest.toml
@@ -6,6 +6,7 @@ packages = [
   { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
@@ -18,10 +19,13 @@ packages = [
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.68.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F7FAEBD8EF260664E86A46C8DBA23508D1D11BB3BCC6EE1B89B3BC3E5C83FF1E" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "tom", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "90791DA4AACE637E30081FE77049B8DB850FBC8CACC31515376BCC4E59BE1DD2" },
 ]
@@ -33,4 +37,5 @@ gleam_httpc = { version = ">= 5.0.0 and < 6.0.0" }
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
 gleam_time = { version = ">= 1.7.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }

--- a/packages/vestibule_apple/gleam.toml
+++ b/packages/vestibule_apple/gleam.toml
@@ -22,3 +22,21 @@ ref = "0f49223187fe57f646642ad0be12468c400401a2"
 
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+# See root gleam.toml for rationale; these rules conflict with vestibule's
+# deliberate library patterns.
+[tools.glinter]
+# Strict lint: any warning fails the build. glinter only supports this
+# globally (no per-rule error severity), so label_possible is turned off
+# below to keep intentional unlabelled subject/pipe first-args from failing.
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Argument labels are encouraged but not enforced: many functions intentionally
+# leave their subject/pipe-receiver first arg unlabelled.
+label_possible = "off"
+unused_exports = "off"
+assert_ok_pattern = "off"
+error_context_lost = "off"
+thrown_away_error = "off"

--- a/packages/vestibule_apple/manifest.toml
+++ b/packages/vestibule_apple/manifest.toml
@@ -8,6 +8,7 @@ packages = [
   { name = "bravo", version = "0.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], source = "git", repo = "https://github.com/Michael-Mark-Edu/bravo", commit = "0f49223187fe57f646642ad0be12468c400401a2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
@@ -20,11 +21,14 @@ packages = [
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.69.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "AAB0962BEBFAA67A2FBEE9EEE218B057756808DC9AF77430F5182C6115B3A315" },
   { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "glow_auth", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_json", "gleam_stdlib", "gleam_time"], otp_app = "glow_auth", source = "hex", outer_checksum = "BCF868EC62BA7431A38D267EF00CFD846E28C6EAA5B349CB3099EAC013C6C7CB" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "tom", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "90791DA4AACE637E30081FE77049B8DB850FBC8CACC31515376BCC4E59BE1DD2" },
   { name = "vestibule", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_http", "gleam_httpc", "gleam_json", "gleam_stdlib", "gleam_time"], source = "local", path = "../.." },
@@ -39,6 +43,7 @@ gleam_httpc = { version = ">= 5.0.0 and < 6.0.0" }
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
 gleam_time = { version = ">= 1.7.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 glow_auth = { version = ">= 1.0.1 and < 2.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }
 vestibule = { path = "../.." }

--- a/packages/vestibule_apple/src/vestibule_apple.gleam
+++ b/packages/vestibule_apple/src/vestibule_apple.gleam
@@ -202,9 +202,9 @@ fn id_token_artifacts(
 ///
 /// Returns the user's `sub` (uid) and `UserInfo` on success.
 pub fn verify_id_token(
-  jwt: String,
-  keys: List(VerifyKey),
-  client_id: String,
+  jwt jwt: String,
+  keys keys: List(VerifyKey),
+  client_id client_id: String,
 ) -> Result(#(String, user_info.UserInfo), AuthError(e)) {
   let claims = [
     claim.issuer("https://appleid.apple.com", []),
@@ -429,9 +429,9 @@ fn do_fetch_user(
   )
   use keys <- result.try(jwks.get_keys(apple.jwks))
   use #(uid, info) <- result.try(verify_id_token(
-    id_token,
-    keys,
-    config.client_id(cfg),
+    jwt: id_token,
+    keys: keys,
+    client_id: config.client_id(cfg),
   ))
   Ok(strategy.user_result(uid: uid, info: info, extra: dict.new()))
 }

--- a/packages/vestibule_apple/src/vestibule_apple/jwks.gleam
+++ b/packages/vestibule_apple/src/vestibule_apple/jwks.gleam
@@ -68,7 +68,8 @@ pub fn get_keys(cache: JwksCache) -> Result(List(VerifyKey), AuthError(e)) {
     Ok(keys) -> Ok(keys)
     Error(_) -> {
       use keys <- result.try(fetch_keys())
-      let _ = uset.insert(into: cache.table, key: cache_key, value: keys)
+      let _inserted =
+        uset.insert(into: cache.table, key: cache_key, value: keys)
       Ok(keys)
     }
   }
@@ -77,7 +78,7 @@ pub fn get_keys(cache: JwksCache) -> Result(List(VerifyKey), AuthError(e)) {
 /// Force refresh the cached keys from Apple's endpoint.
 pub fn refresh_keys(cache: JwksCache) -> Result(List(VerifyKey), AuthError(e)) {
   use keys <- result.try(fetch_keys())
-  let _ = uset.insert(into: cache.table, key: cache_key, value: keys)
+  let _inserted = uset.insert(into: cache.table, key: cache_key, value: keys)
   Ok(keys)
 }
 

--- a/packages/vestibule_apple/test/vestibule_apple_security_test.gleam
+++ b/packages/vestibule_apple/test/vestibule_apple_security_test.gleam
@@ -48,9 +48,9 @@ pub fn verify_id_token_rejects_wrong_key_test() {
 
   let result =
     vestibule_apple.verify_id_token(
-      token,
-      [verify_key.derived(legit_key)],
-      "com.example.app",
+      jwt: token,
+      keys: [verify_key.derived(legit_key)],
+      client_id: "com.example.app",
     )
   let _ = result |> expect.to_be_error()
   Nil
@@ -80,9 +80,9 @@ pub fn verify_id_token_accepts_correct_key_test() {
 
   let result =
     vestibule_apple.verify_id_token(
-      token,
-      [verify_key.derived(key)],
-      "com.example.app",
+      jwt: token,
+      keys: [verify_key.derived(key)],
+      client_id: "com.example.app",
     )
   let assert Ok(#(uid, info)) = result
   uid |> expect.to_equal("user-123")
@@ -109,9 +109,9 @@ pub fn verify_id_token_rejects_wrong_issuer_test() {
 
   let result =
     vestibule_apple.verify_id_token(
-      token,
-      [verify_key.derived(key)],
-      "com.example.app",
+      jwt: token,
+      keys: [verify_key.derived(key)],
+      client_id: "com.example.app",
     )
   let _ = result |> expect.to_be_error()
   Nil
@@ -137,9 +137,9 @@ pub fn verify_id_token_rejects_wrong_audience_test() {
 
   let result =
     vestibule_apple.verify_id_token(
-      token,
-      [verify_key.derived(key)],
-      "com.example.app",
+      jwt: token,
+      keys: [verify_key.derived(key)],
+      client_id: "com.example.app",
     )
   let _ = result |> expect.to_be_error()
   Nil
@@ -155,9 +155,9 @@ pub fn verify_id_token_rejects_forged_jwt_test() {
 
   let result =
     vestibule_apple.verify_id_token(
-      forged_jwt,
-      [verify_key.derived(key)],
-      "com.example.app",
+      jwt: forged_jwt,
+      keys: [verify_key.derived(key)],
+      client_id: "com.example.app",
     )
   let _ = result |> expect.to_be_error()
   Nil
@@ -187,9 +187,9 @@ pub fn verify_id_token_unverified_email_not_returned_test() {
 
   let assert Ok(#(_, info)) =
     vestibule_apple.verify_id_token(
-      token,
-      [verify_key.derived(key)],
-      "com.example.app",
+      jwt: token,
+      keys: [verify_key.derived(key)],
+      client_id: "com.example.app",
     )
   info.email |> expect.to_equal(None)
   info.nickname |> expect.to_equal(Some("user@example.com"))

--- a/packages/vestibule_apple/test/vestibule_apple_test.gleam
+++ b/packages/vestibule_apple/test/vestibule_apple_test.gleam
@@ -122,9 +122,19 @@ pub fn parse_token_response_error_without_description_test() {
 
 pub fn authorize_url_invalid_redirect_uri_returns_error_test() {
   let strat = vestibule_apple.strategy(test_apple_cache("invalid_redirect"))
-  let conf = config.new("client-id", "secret", "not a uri")
+  let conf =
+    config.new(
+      client_id: "client-id",
+      client_secret: "secret",
+      redirect_uri: "not a uri",
+    )
   let _ =
-    strategy.build_authorize_url(strat, conf, ["name", "email"], "state")
+    strategy.build_authorize_url(
+      strat,
+      cfg: conf,
+      scopes: ["name", "email"],
+      state: "state",
+    )
     |> expect.to_be_error()
   Nil
 }

--- a/packages/vestibule_github/gleam.toml
+++ b/packages/vestibule_github/gleam.toml
@@ -15,3 +15,19 @@ glow_auth = ">= 1.0.1 and < 2.0.0"
 
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+# See root gleam.toml for rationale; these rules conflict with vestibule's
+# deliberate library patterns.
+[tools.glinter]
+# Strict lint: any warning fails the build. glinter only supports this
+# globally (no per-rule error severity), so label_possible is turned off
+# below to keep intentional unlabelled subject/pipe first-args from failing.
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Argument labels are encouraged but not enforced: many functions intentionally
+# leave their subject/pipe-receiver first arg unlabelled.
+label_possible = "off"
+error_context_lost = "off"
+thrown_away_error = "off"

--- a/packages/vestibule_github/manifest.toml
+++ b/packages/vestibule_github/manifest.toml
@@ -6,6 +6,7 @@ packages = [
   { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_crypto", version = "1.5.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "43A25BCE17834475AEA7FFC9408B6D0FC1D709A682BCAE5FEFC6D4192CF47718" },
@@ -18,11 +19,14 @@ packages = [
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "glow_auth", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_json", "gleam_stdlib", "gleam_time"], otp_app = "glow_auth", source = "hex", outer_checksum = "BCF868EC62BA7431A38D267EF00CFD846E28C6EAA5B349CB3099EAC013C6C7CB" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
   { name = "vestibule", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_http", "gleam_httpc", "gleam_json", "gleam_stdlib", "gleam_time"], source = "local", path = "../.." },
@@ -33,6 +37,7 @@ gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
 gleam_httpc = { version = ">= 5.0.0 and < 6.0.0" }
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 glow_auth = { version = ">= 1.0.1 and < 2.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }
 vestibule = { path = "../.." }

--- a/packages/vestibule_github/test/vestibule_github_test.gleam
+++ b/packages/vestibule_github/test/vestibule_github_test.gleam
@@ -96,9 +96,19 @@ pub fn parse_emails_no_verified_primary_test() {
 
 pub fn authorize_url_invalid_redirect_uri_returns_error_test() {
   let strat = vestibule_github.strategy()
-  let conf = config.new("client-id", "secret", "not a uri")
+  let conf =
+    config.new(
+      client_id: "client-id",
+      client_secret: "secret",
+      redirect_uri: "not a uri",
+    )
   let _ =
-    strategy.build_authorize_url(strat, conf, ["user:email"], "state")
+    strategy.build_authorize_url(
+      strat,
+      cfg: conf,
+      scopes: ["user:email"],
+      state: "state",
+    )
     |> expect.to_be_error()
   Nil
 }
@@ -106,9 +116,18 @@ pub fn authorize_url_invalid_redirect_uri_returns_error_test() {
 pub fn authorize_url_includes_extra_params_test() {
   let strat = vestibule_github.strategy()
   let assert Ok(conf) =
-    config.new("client-id", "secret", "http://localhost/callback")
+    config.new(
+      client_id: "client-id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/callback",
+    )
     |> config.with_extra_params([#("allow_signup", "false")])
   let assert Ok(url) =
-    strategy.build_authorize_url(strat, conf, ["user:email"], "state")
+    strategy.build_authorize_url(
+      strat,
+      cfg: conf,
+      scopes: ["user:email"],
+      state: "state",
+    )
   { string.contains(url, "allow_signup=false") } |> expect.to_be_true()
 }

--- a/packages/vestibule_google/gleam.toml
+++ b/packages/vestibule_google/gleam.toml
@@ -15,3 +15,18 @@ glow_auth = ">= 1.0.1 and < 2.0.0"
 
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+# See root gleam.toml for rationale; low-level errors are mapped into
+# descriptive domain AuthError variants by design.
+[tools.glinter]
+# Strict lint: any warning fails the build. glinter only supports this
+# globally (no per-rule error severity), so label_possible is turned off
+# below to keep intentional unlabelled subject/pipe first-args from failing.
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Argument labels are encouraged but not enforced: many functions intentionally
+# leave their subject/pipe-receiver first arg unlabelled.
+label_possible = "off"
+error_context_lost = "off"

--- a/packages/vestibule_google/manifest.toml
+++ b/packages/vestibule_google/manifest.toml
@@ -6,6 +6,7 @@ packages = [
   { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
@@ -18,11 +19,14 @@ packages = [
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.69.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "AAB0962BEBFAA67A2FBEE9EEE218B057756808DC9AF77430F5182C6115B3A315" },
   { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "glow_auth", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_json", "gleam_stdlib", "gleam_time"], otp_app = "glow_auth", source = "hex", outer_checksum = "BCF868EC62BA7431A38D267EF00CFD846E28C6EAA5B349CB3099EAC013C6C7CB" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "tom", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "90791DA4AACE637E30081FE77049B8DB850FBC8CACC31515376BCC4E59BE1DD2" },
   { name = "vestibule", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_http", "gleam_httpc", "gleam_json", "gleam_stdlib", "gleam_time"], source = "local", path = "../.." },
@@ -33,6 +37,7 @@ gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
 gleam_httpc = { version = ">= 5.0.0 and < 6.0.0" }
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 glow_auth = { version = ">= 1.0.1 and < 2.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }
 vestibule = { path = "../.." }

--- a/packages/vestibule_google/src/vestibule_google.gleam
+++ b/packages/vestibule_google/src/vestibule_google.gleam
@@ -156,8 +156,8 @@ pub fn parse_user_response_with_hd(
 /// exactly, otherwise authentication fails with `error.UserInfoFailed`. This
 /// is the enforcement primitive behind `strategy_for_hosted_domain`.
 pub fn validate_hosted_domain(
-  required: Option(String),
-  returned: Option(String),
+  required required: Option(String),
+  returned returned: Option(String),
 ) -> Result(Option(String), AuthError(e)) {
   case required, returned {
     None, _ -> Ok(returned)
@@ -326,8 +326,8 @@ fn fetch_user_enforcing(
     ),
   )
   use validated_hd <- result.try(validate_hosted_domain(
-    required_hd,
-    returned_hd,
+    required: required_hd,
+    returned: returned_hd,
   ))
   let extra = case validated_hd {
     Some(domain) -> dict.from_list([#("hd", dynamic.string(domain))])

--- a/packages/vestibule_google/test/vestibule_google_test.gleam
+++ b/packages/vestibule_google/test/vestibule_google_test.gleam
@@ -110,9 +110,19 @@ pub fn parse_user_response_minimal_test() {
 
 pub fn authorize_url_invalid_redirect_uri_returns_error_test() {
   let strat = vestibule_google.strategy()
-  let conf = config.new("client-id", "secret", "not a uri")
+  let conf =
+    config.new(
+      client_id: "client-id",
+      client_secret: "secret",
+      redirect_uri: "not a uri",
+    )
   let _ =
-    strategy.build_authorize_url(strat, conf, ["openid"], "state")
+    strategy.build_authorize_url(
+      strat,
+      cfg: conf,
+      scopes: ["openid"],
+      state: "state",
+    )
     |> expect.to_be_error()
   Nil
 }
@@ -120,10 +130,19 @@ pub fn authorize_url_invalid_redirect_uri_returns_error_test() {
 pub fn authorize_url_includes_extra_params_test() {
   let strat = vestibule_google.strategy()
   let assert Ok(conf) =
-    config.new("client-id", "secret", "http://localhost/callback")
+    config.new(
+      client_id: "client-id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/callback",
+    )
     |> config.with_extra_params([#("prompt", "consent")])
   let assert Ok(url) =
-    strategy.build_authorize_url(strat, conf, ["openid"], "state")
+    strategy.build_authorize_url(
+      strat,
+      cfg: conf,
+      scopes: ["openid"],
+      state: "state",
+    )
   { string.contains(url, "prompt=consent") } |> expect.to_be_true()
 }
 
@@ -148,8 +167,8 @@ pub fn parse_user_response_with_hd_absent_test() {
 
 pub fn validate_hosted_domain_match_test() {
   vestibule_google.validate_hosted_domain(
-    Some("corp.example"),
-    Some("corp.example"),
+    required: Some("corp.example"),
+    returned: Some("corp.example"),
   )
   |> expect.to_be_ok()
   |> expect.to_equal(Some("corp.example"))
@@ -157,8 +176,8 @@ pub fn validate_hosted_domain_match_test() {
 
 pub fn validate_hosted_domain_mismatch_fails_test() {
   vestibule_google.validate_hosted_domain(
-    Some("corp.example"),
-    Some("evil.com"),
+    required: Some("corp.example"),
+    returned: Some("evil.com"),
   )
   |> expect.to_be_error()
   |> fn(err) {
@@ -170,7 +189,10 @@ pub fn validate_hosted_domain_mismatch_fails_test() {
 }
 
 pub fn validate_hosted_domain_missing_claim_fails_test() {
-  vestibule_google.validate_hosted_domain(Some("corp.example"), None)
+  vestibule_google.validate_hosted_domain(
+    required: Some("corp.example"),
+    returned: None,
+  )
   |> expect.to_be_error()
   |> fn(err) {
     case err {
@@ -181,19 +203,32 @@ pub fn validate_hosted_domain_missing_claim_fails_test() {
 }
 
 pub fn validate_hosted_domain_not_required_passes_through_test() {
-  vestibule_google.validate_hosted_domain(None, Some("corp.example"))
+  vestibule_google.validate_hosted_domain(
+    required: None,
+    returned: Some("corp.example"),
+  )
   |> expect.to_be_ok()
   |> expect.to_equal(Some("corp.example"))
 
-  vestibule_google.validate_hosted_domain(None, None)
+  vestibule_google.validate_hosted_domain(required: None, returned: None)
   |> expect.to_be_ok()
   |> expect.to_equal(None)
 }
 
 pub fn strategy_for_hosted_domain_authorize_url_includes_hd_hint_test() {
   let strat = vestibule_google.strategy_for_hosted_domain("corp.example")
-  let conf = config.new("client-id", "secret", "http://localhost/callback")
+  let conf =
+    config.new(
+      client_id: "client-id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/callback",
+    )
   let assert Ok(url) =
-    strategy.build_authorize_url(strat, conf, ["openid"], "state")
+    strategy.build_authorize_url(
+      strat,
+      cfg: conf,
+      scopes: ["openid"],
+      state: "state",
+    )
   { string.contains(url, "hd=corp.example") } |> expect.to_be_true()
 }

--- a/packages/vestibule_microsoft/gleam.toml
+++ b/packages/vestibule_microsoft/gleam.toml
@@ -16,3 +16,19 @@ glow_auth = ">= 1.0.1 and < 2.0.0"
 
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+# See root gleam.toml for rationale; these rules conflict with vestibule's
+# deliberate library patterns.
+[tools.glinter]
+# Strict lint: any warning fails the build. glinter only supports this
+# globally (no per-rule error severity), so label_possible is turned off
+# below to keep intentional unlabelled subject/pipe first-args from failing.
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Argument labels are encouraged but not enforced: many functions intentionally
+# leave their subject/pipe-receiver first arg unlabelled.
+label_possible = "off"
+error_context_lost = "off"
+thrown_away_error = "off"

--- a/packages/vestibule_microsoft/manifest.toml
+++ b/packages/vestibule_microsoft/manifest.toml
@@ -6,6 +6,7 @@ packages = [
   { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
@@ -18,11 +19,14 @@ packages = [
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.69.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "AAB0962BEBFAA67A2FBEE9EEE218B057756808DC9AF77430F5182C6115B3A315" },
   { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "glow_auth", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_json", "gleam_stdlib", "gleam_time"], otp_app = "glow_auth", source = "hex", outer_checksum = "BCF868EC62BA7431A38D267EF00CFD846E28C6EAA5B349CB3099EAC013C6C7CB" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "tom", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "90791DA4AACE637E30081FE77049B8DB850FBC8CACC31515376BCC4E59BE1DD2" },
   { name = "vestibule", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_http", "gleam_httpc", "gleam_json", "gleam_stdlib", "gleam_time"], source = "local", path = "../.." },
@@ -34,6 +38,7 @@ gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
 gleam_httpc = { version = ">= 5.0.0 and < 6.0.0" }
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 glow_auth = { version = ">= 1.0.1 and < 2.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }
 vestibule = { path = "../.." }

--- a/packages/vestibule_microsoft/src/vestibule_microsoft.gleam
+++ b/packages/vestibule_microsoft/src/vestibule_microsoft.gleam
@@ -343,7 +343,10 @@ fn enforce_tenant(
     None -> Ok(Nil)
     Some(tenant) -> {
       use id_token <- result.try(exchange_id_token(exchange))
-      use _ <- result.try(verify_tenant(tenant, id_token))
+      use _ <- result.try(verify_tenant(
+        expected_tenant: tenant,
+        id_token: id_token,
+      ))
       Ok(Nil)
     }
   }
@@ -359,16 +362,12 @@ fn exchange_id_token(
         Ok(token) -> Ok(token)
         Error(_) ->
           Error(error.UserInfoFailed(
-            reason: "Microsoft tenant enforcement requires an ID token, "
-            <> "but the token response did not include one. Ensure the "
-            <> "`openid` scope is requested.",
+            reason: "Microsoft tenant enforcement requires an ID token, but the token response did not include one. Ensure the `openid` scope is requested.",
           ))
       }
     Error(_) ->
       Error(error.UserInfoFailed(
-        reason: "Microsoft tenant enforcement requires an ID token, but the "
-        <> "token response did not include one. Ensure the `openid` scope is "
-        <> "requested.",
+        reason: "Microsoft tenant enforcement requires an ID token, but the token response did not include one. Ensure the `openid` scope is requested.",
       ))
   }
 }
@@ -385,8 +384,8 @@ fn exchange_id_token(
 /// Microsoft's token endpoint over TLS, so its payload is trusted without a
 /// separate JWKS signature check (OpenID Connect Core 1.0, section 3.1.3.7).
 pub fn verify_tenant(
-  expected_tenant: String,
-  id_token: String,
+  expected_tenant expected_tenant: String,
+  id_token id_token: String,
 ) -> Result(String, AuthError(e)) {
   use tid <- result.try(id_token_tenant(id_token))
   case string.lowercase(tid) == string.lowercase(expected_tenant) {
@@ -447,8 +446,7 @@ fn decode_jwt_payload(id_token: String) -> Result(String, AuthError(e)) {
       }
     _ ->
       Error(error.UserInfoFailed(
-        reason: "Malformed Microsoft ID token: expected a JWT with a payload "
-        <> "segment",
+        reason: "Malformed Microsoft ID token: expected a JWT with a payload segment",
       ))
   }
 }

--- a/packages/vestibule_microsoft/test/vestibule_microsoft_test.gleam
+++ b/packages/vestibule_microsoft/test/vestibule_microsoft_test.gleam
@@ -24,8 +24,8 @@ pub fn verify_tenant_match_test() {
   let token =
     fake_id_token("{\"tid\":\"72f988bf-86f1-41af-91ab-2d7cd011db47\"}")
   vestibule_microsoft.verify_tenant(
-    "72f988bf-86f1-41af-91ab-2d7cd011db47",
-    token,
+    expected_tenant: "72f988bf-86f1-41af-91ab-2d7cd011db47",
+    id_token: token,
   )
   |> expect.to_be_ok()
   |> expect.to_equal("72f988bf-86f1-41af-91ab-2d7cd011db47")
@@ -35,8 +35,8 @@ pub fn verify_tenant_case_insensitive_test() {
   let token =
     fake_id_token("{\"tid\":\"72F988BF-86F1-41AF-91AB-2D7CD011DB47\"}")
   vestibule_microsoft.verify_tenant(
-    "72f988bf-86f1-41af-91ab-2d7cd011db47",
-    token,
+    expected_tenant: "72f988bf-86f1-41af-91ab-2d7cd011db47",
+    id_token: token,
   )
   |> expect.to_be_ok()
   Nil
@@ -45,7 +45,10 @@ pub fn verify_tenant_case_insensitive_test() {
 pub fn verify_tenant_mismatch_rejected_test() {
   let token = fake_id_token("{\"tid\":\"other-tenant-guid\"}")
   let _ =
-    vestibule_microsoft.verify_tenant("expected-tenant-guid", token)
+    vestibule_microsoft.verify_tenant(
+      expected_tenant: "expected-tenant-guid",
+      id_token: token,
+    )
     |> expect.to_be_error()
   Nil
 }
@@ -53,14 +56,20 @@ pub fn verify_tenant_mismatch_rejected_test() {
 pub fn verify_tenant_missing_tid_rejected_test() {
   let token = fake_id_token("{\"sub\":\"abc\"}")
   let _ =
-    vestibule_microsoft.verify_tenant("expected-tenant-guid", token)
+    vestibule_microsoft.verify_tenant(
+      expected_tenant: "expected-tenant-guid",
+      id_token: token,
+    )
     |> expect.to_be_error()
   Nil
 }
 
 pub fn verify_tenant_malformed_token_rejected_test() {
   let _ =
-    vestibule_microsoft.verify_tenant("expected-tenant-guid", "not-a-jwt")
+    vestibule_microsoft.verify_tenant(
+      expected_tenant: "expected-tenant-guid",
+      id_token: "not-a-jwt",
+    )
     |> expect.to_be_error()
   Nil
 }
@@ -74,9 +83,19 @@ pub fn id_token_tenant_extracts_tid_test() {
 
 pub fn strategy_for_tenant_authorize_url_uses_tenant_endpoint_test() {
   let strat = vestibule_microsoft.strategy_for_tenant("my-tenant-id")
-  let conf = config.new("client-id", "secret", "http://localhost/callback")
+  let conf =
+    config.new(
+      client_id: "client-id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/callback",
+    )
   let assert Ok(url) =
-    strategy.build_authorize_url(strat, conf, ["openid", "User.Read"], "state")
+    strategy.build_authorize_url(
+      strat,
+      cfg: conf,
+      scopes: ["openid", "User.Read"],
+      state: "state",
+    )
   { string.contains(url, "login.microsoftonline.com/my-tenant-id/oauth2/v2.0") }
   |> expect.to_be_true()
 }
@@ -89,9 +108,19 @@ pub fn strategy_for_tenant_default_scopes_include_openid_test() {
 
 pub fn common_strategy_authorize_url_uses_common_endpoint_test() {
   let strat = vestibule_microsoft.strategy()
-  let conf = config.new("client-id", "secret", "http://localhost/callback")
+  let conf =
+    config.new(
+      client_id: "client-id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/callback",
+    )
   let assert Ok(url) =
-    strategy.build_authorize_url(strat, conf, ["User.Read"], "state")
+    strategy.build_authorize_url(
+      strat,
+      cfg: conf,
+      scopes: ["User.Read"],
+      state: "state",
+    )
   { string.contains(url, "login.microsoftonline.com/common/oauth2/v2.0") }
   |> expect.to_be_true()
 }
@@ -179,9 +208,19 @@ pub fn parse_user_response_mail_preferred_over_upn_test() {
 
 pub fn authorize_url_invalid_redirect_uri_returns_error_test() {
   let strat = vestibule_microsoft.strategy()
-  let conf = config.new("client-id", "secret", "not a uri")
+  let conf =
+    config.new(
+      client_id: "client-id",
+      client_secret: "secret",
+      redirect_uri: "not a uri",
+    )
   let _ =
-    strategy.build_authorize_url(strat, conf, ["User.Read"], "state")
+    strategy.build_authorize_url(
+      strat,
+      cfg: conf,
+      scopes: ["User.Read"],
+      state: "state",
+    )
     |> expect.to_be_error()
   Nil
 }
@@ -189,9 +228,18 @@ pub fn authorize_url_invalid_redirect_uri_returns_error_test() {
 pub fn authorize_url_includes_extra_params_test() {
   let strat = vestibule_microsoft.strategy()
   let assert Ok(conf) =
-    config.new("client-id", "secret", "http://localhost/callback")
+    config.new(
+      client_id: "client-id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/callback",
+    )
     |> config.with_extra_params([#("prompt", "select_account")])
   let assert Ok(url) =
-    strategy.build_authorize_url(strat, conf, ["User.Read"], "state")
+    strategy.build_authorize_url(
+      strat,
+      cfg: conf,
+      scopes: ["User.Read"],
+      state: "state",
+    )
   { string.contains(url, "prompt=select_account") } |> expect.to_be_true()
 }

--- a/packages/vestibule_mist/gleam.toml
+++ b/packages/vestibule_mist/gleam.toml
@@ -15,3 +15,19 @@ gleam_erlang = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+# See root gleam.toml for rationale; these rules conflict with vestibule's
+# deliberate library patterns (public API exports, domain error mapping).
+[tools.glinter]
+# Strict lint: any warning fails the build. glinter only supports this
+# globally (no per-rule error severity), so label_possible is turned off
+# below to keep intentional unlabelled subject/pipe first-args from failing.
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Argument labels are encouraged but not enforced: many functions intentionally
+# leave their subject/pipe-receiver first arg unlabelled.
+label_possible = "off"
+unused_exports = "off"
+error_context_lost = "off"

--- a/packages/vestibule_mist/manifest.toml
+++ b/packages/vestibule_mist/manifest.toml
@@ -6,6 +6,7 @@ packages = [
   { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_crypto", version = "1.5.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "43A25BCE17834475AEA7FFC9408B6D0FC1D709A682BCAE5FEFC6D4192CF47718" },
@@ -18,7 +19,9 @@ packages = [
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "glisten", version = "9.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "D92808C66F7D3F22F2289CD04CBA8151757AAE9CB3D86992F0C6DE32A41205E1" },
   { name = "gramps", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "8B7195978FBFD30B43DF791A8A272041B81E45D245314D7A41FC57237AA882A0" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
@@ -27,6 +30,7 @@ packages = [
   { name = "mist", version = "6.0.2", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "6B03DEEA38A02F276333CB27B53B16D3D45BD741B89599085A601BAF635F2006" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
   { name = "vestibule", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_http", "gleam_httpc", "gleam_json", "gleam_stdlib", "gleam_time"], source = "local", path = "../.." },
@@ -37,6 +41,7 @@ gleam_crypto = { version = ">= 1.5.0 and < 2.0.0" }
 gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 mist = { version = ">= 6.0.0 and < 7.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }
 vestibule = { path = "../.." }

--- a/packages/vestibule_mist/src/vestibule_mist.gleam
+++ b/packages/vestibule_mist/src/vestibule_mist.gleam
@@ -102,16 +102,20 @@ pub fn request_phase(
   case
     transport_flow.start_authorization(
       reg,
-      provider,
-      store,
-      options.session_ttl_seconds,
+      provider: provider,
+      store: store,
+      ttl_seconds: options.session_ttl_seconds,
     )
   {
     Error(transport_flow.UnknownProvider(_)) -> not_found_response()
     Error(transport_flow.AuthFailed(_)) -> generic_error_response()
     Error(transport_flow.StoreFailed(_)) -> generic_error_response()
     Ok(#(url, session_id)) -> {
-      let token = signed_cookie.sign(session_id, options.secret_key_base)
+      let token =
+        signed_cookie.sign(
+          payload: session_id,
+          secret_key_base: options.secret_key_base,
+        )
       let attrs =
         cookie.Attributes(
           max_age: option.Some(options.session_ttl_seconds),
@@ -145,7 +149,15 @@ pub fn callback_phase(
   options: Options,
   on_success: fn(Auth) -> Response(ResponseData),
 ) -> Response(ResponseData) {
-  case callback_phase_auth_result(req, reg, provider, store, options) {
+  case
+    callback_phase_auth_result(
+      req,
+      reg: reg,
+      provider: provider,
+      store: store,
+      options: options,
+    )
+  {
     Ok(auth) -> on_success(auth)
     Error(err) -> callback_error_response(err)
   }
@@ -158,12 +170,18 @@ pub fn callback_phase(
 /// success value or generated error response yourself.
 pub fn callback_phase_result(
   req: Request(Connection),
-  reg: Registry(e),
-  provider: String,
-  store: StateStore,
-  options: Options,
+  reg reg: Registry(e),
+  provider provider: String,
+  store store: StateStore,
+  options options: Options,
 ) -> Result(Auth, Response(ResponseData)) {
-  callback_phase_auth_result(req, reg, provider, store, options)
+  callback_phase_auth_result(
+    req,
+    reg: reg,
+    provider: provider,
+    store: store,
+    options: options,
+  )
   |> result.map_error(callback_error_response)
 }
 
@@ -178,19 +196,19 @@ pub fn callback_phase_result(
 /// valid in-flight login.
 pub fn callback_phase_auth_result(
   req: Request(Connection),
-  reg: Registry(e),
-  provider: String,
-  store: StateStore,
-  options: Options,
+  reg reg: Registry(e),
+  provider provider: String,
+  store store: StateStore,
+  options options: Options,
 ) -> Result(Auth, CallbackError(e)) {
   use params <- result.try(get_callback_params(req))
   callback_phase_auth_result_with_params(
     req,
-    params,
-    reg,
-    provider,
-    store,
-    options,
+    params: params,
+    reg: reg,
+    provider: provider,
+    store: store,
+    options: options,
   )
 }
 
@@ -202,11 +220,11 @@ pub fn callback_phase_auth_result(
 /// `Request(BitArray)` or any other body.
 pub fn callback_phase_auth_result_with_params(
   req: Request(body),
-  params: dict.Dict(String, String),
-  reg: Registry(e),
-  provider: String,
-  store: StateStore,
-  options: Options,
+  params params: dict.Dict(String, String),
+  reg reg: Registry(e),
+  provider provider: String,
+  store store: StateStore,
+  options options: Options,
 ) -> Result(Auth, CallbackError(e)) {
   use strategy_config <- result.try(
     transport_flow.ensure_callback_provider(reg, provider)
@@ -219,7 +237,12 @@ pub fn callback_phase_auth_result_with_params(
     options.secret_key_base,
   ))
 
-  transport_flow.finish_callback(strategy_config, store, params, session_id)
+  transport_flow.finish_callback(
+    strategy_config,
+    store: store,
+    params: params,
+    session_id: session_id,
+  )
   |> result.map_error(map_callback_flow_error)
 }
 
@@ -232,7 +255,7 @@ fn get_signed_cookie(
   case list.key_find(cookies, cookie_name) {
     Error(Nil) -> Error(MissingOrInvalidSessionCookie)
     Ok(token) ->
-      signed_cookie.verify(token, secret_key_base)
+      signed_cookie.verify(token: token, secret_key_base: secret_key_base)
       |> result.map_error(fn(_) { MissingOrInvalidSessionCookie })
   }
 }

--- a/packages/vestibule_mist/src/vestibule_mist/signed_cookie.gleam
+++ b/packages/vestibule_mist/src/vestibule_mist/signed_cookie.gleam
@@ -11,7 +11,10 @@ import gleam/result
 /// Sign `payload` with `secret_key_base` using HMAC-SHA256 and return a
 /// URL-safe token (`protected.payload.signature`) suitable for use as a
 /// cookie value.
-pub fn sign(payload: String, secret_key_base: BitArray) -> String {
+pub fn sign(
+  payload payload: String,
+  secret_key_base secret_key_base: BitArray,
+) -> String {
   crypto.sign_message(
     bit_array.from_string(payload),
     secret_key_base,
@@ -22,7 +25,10 @@ pub fn sign(payload: String, secret_key_base: BitArray) -> String {
 /// Verify a token previously produced by `sign/2`. Returns the original
 /// payload string, or `Error(Nil)` if the token is malformed, the
 /// signature does not match, or the payload is not valid UTF-8.
-pub fn verify(token: String, secret_key_base: BitArray) -> Result(String, Nil) {
+pub fn verify(
+  token token: String,
+  secret_key_base secret_key_base: BitArray,
+) -> Result(String, Nil) {
   use payload_bits <- result.try(crypto.verify_signed_message(
     token,
     secret_key_base,

--- a/packages/vestibule_mist/test/vestibule_mist_test.gleam
+++ b/packages/vestibule_mist/test/vestibule_mist_test.gleam
@@ -21,8 +21,9 @@ pub fn main() -> Nil {
 
 pub fn signed_cookie_round_trip_test() {
   let secret = test_secret()
-  let token = signed_cookie.sign("session-id-123", secret)
-  signed_cookie.verify(token, secret)
+  let token =
+    signed_cookie.sign(payload: "session-id-123", secret_key_base: secret)
+  signed_cookie.verify(token: token, secret_key_base: secret)
   |> expect.to_be_ok()
   |> expect.to_equal("session-id-123")
 }
@@ -30,20 +31,25 @@ pub fn signed_cookie_round_trip_test() {
 pub fn signed_cookie_verify_with_wrong_secret_fails_test() {
   let secret = test_secret()
   let other = <<"different-key-also-32-bytes-long":utf8>>
-  let token = signed_cookie.sign("session-id-123", secret)
-  signed_cookie.verify(token, other)
+  let token =
+    signed_cookie.sign(payload: "session-id-123", secret_key_base: secret)
+  signed_cookie.verify(token: token, secret_key_base: other)
   |> expect.to_be_error()
 }
 
 pub fn signed_cookie_verify_with_tampered_token_fails_test() {
   let secret = test_secret()
-  let token = signed_cookie.sign("session-id-123", secret)
-  signed_cookie.verify(token <> "x", secret)
+  let token =
+    signed_cookie.sign(payload: "session-id-123", secret_key_base: secret)
+  signed_cookie.verify(token: token <> "x", secret_key_base: secret)
   |> expect.to_be_error()
 }
 
 pub fn signed_cookie_verify_malformed_token_fails_test() {
-  signed_cookie.verify("not-a-valid-token", test_secret())
+  signed_cookie.verify(
+    token: "not-a-valid-token",
+    secret_key_base: test_secret(),
+  )
   |> expect.to_be_error()
 }
 
@@ -83,7 +89,7 @@ pub fn request_phase_success_sets_signed_cookie_and_redirects_test() {
   let store = state_store.init_named("test_mist_request_success")
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy(), test_config())
+    |> registry.register(strategy: test_strategy(), config: test_config())
 
   let resp =
     vestibule_mist.request_phase(req, reg, "test", store, test_options())
@@ -106,7 +112,7 @@ pub fn request_phase_allows_secure_cookie_opt_out_test() {
   let store = state_store.init_named("test_mist_request_secure_cookie_opt_out")
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy(), test_config())
+    |> registry.register(strategy: test_strategy(), config: test_config())
   let options = vestibule_mist.Options(..test_options(), secure_cookie: False)
 
   let resp = vestibule_mist.request_phase(req, reg, "test", store, options)
@@ -137,7 +143,7 @@ pub fn callback_missing_session_cookie_test() {
   let store = state_store.init_named("test_mist_cb_missing_cookie")
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy(), test_config())
+    |> registry.register(strategy: test_strategy(), config: test_config())
 
   vestibule_mist.callback_phase_auth_result_with_params(
     req,
@@ -157,7 +163,7 @@ pub fn callback_tampered_cookie_fails_as_missing_test() {
   let store = state_store.init_named("test_mist_cb_tampered_cookie")
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy(), test_config())
+    |> registry.register(strategy: test_strategy(), config: test_config())
 
   vestibule_mist.callback_phase_auth_result_with_params(
     req,
@@ -172,15 +178,17 @@ pub fn callback_tampered_cookie_fails_as_missing_test() {
 
 pub fn callback_wrong_secret_fails_as_missing_test() {
   let store = state_store.init_named("test_mist_cb_wrong_secret")
-  let session_id = state_store.store(store, "state", "verifier")
+  let session_id =
+    state_store.store(store, state: "state", code_verifier: "verifier")
   let other_secret = <<"some-other-secret-key-base!!!!!!":utf8>>
-  let token = signed_cookie.sign(session_id, other_secret)
+  let token =
+    signed_cookie.sign(payload: session_id, secret_key_base: other_secret)
   let req =
     request.new()
     |> request.set_cookie("vestibule_session", token)
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy(), test_config())
+    |> registry.register(strategy: test_strategy(), config: test_config())
 
   vestibule_mist.callback_phase_auth_result_with_params(
     req,
@@ -195,14 +203,16 @@ pub fn callback_wrong_secret_fails_as_missing_test() {
 
 pub fn callback_missing_state_does_not_consume_session_test() {
   let store = state_store.init_named("test_mist_cb_missing_state_reusable")
-  let session_id = state_store.store(store, "state", "verifier")
-  let token = signed_cookie.sign(session_id, test_secret())
+  let session_id =
+    state_store.store(store, state: "state", code_verifier: "verifier")
+  let token =
+    signed_cookie.sign(payload: session_id, secret_key_base: test_secret())
   let req =
     request.new()
     |> request.set_cookie("vestibule_session", token)
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy(), test_config())
+    |> registry.register(strategy: test_strategy(), config: test_config())
 
   vestibule_mist.callback_phase_auth_result_with_params(
     req,
@@ -231,13 +241,17 @@ pub fn callback_missing_state_does_not_consume_session_test() {
 
 pub fn callback_unknown_session_returns_expired_test() {
   let store = state_store.init_named("test_mist_cb_unknown_session")
-  let token = signed_cookie.sign("nonexistent-session", test_secret())
+  let token =
+    signed_cookie.sign(
+      payload: "nonexistent-session",
+      secret_key_base: test_secret(),
+    )
   let req =
     request.new()
     |> request.set_cookie("vestibule_session", token)
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy(), test_config())
+    |> registry.register(strategy: test_strategy(), config: test_config())
 
   vestibule_mist.callback_phase_auth_result_with_params(
     req,
@@ -252,14 +266,19 @@ pub fn callback_unknown_session_returns_expired_test() {
 
 pub fn callback_auth_result_preserves_provider_error_details_test() {
   let store = state_store.init_named("test_mist_cb_structured_error_details")
-  let session_id = state_store.store(store, "state", "verifier")
-  let token = signed_cookie.sign(session_id, test_secret())
+  let session_id =
+    state_store.store(store, state: "state", code_verifier: "verifier")
+  let token =
+    signed_cookie.sign(payload: session_id, secret_key_base: test_secret())
   let req =
     request.new()
     |> request.set_cookie("vestibule_session", token)
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(leaky_error_strategy(), test_config())
+    |> registry.register(
+      strategy: leaky_error_strategy(),
+      config: test_config(),
+    )
 
   vestibule_mist.callback_phase_auth_result_with_params(
     req,
@@ -282,14 +301,16 @@ pub fn callback_auth_result_preserves_provider_error_details_test() {
 
 pub fn callback_custom_cookie_name_is_honored_test() {
   let store = state_store.init_named("test_mist_cb_custom_cookie_name")
-  let session_id = state_store.store(store, "state", "verifier")
-  let token = signed_cookie.sign(session_id, test_secret())
+  let session_id =
+    state_store.store(store, state: "state", code_verifier: "verifier")
+  let token =
+    signed_cookie.sign(payload: session_id, secret_key_base: test_secret())
   let req =
     request.new()
     |> request.set_cookie("custom_session", token)
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy(), test_config())
+    |> registry.register(strategy: test_strategy(), config: test_config())
 
   vestibule_mist.callback_phase_auth_result_with_params(
     req,
@@ -366,7 +387,11 @@ fn leaky_error_strategy() -> Strategy(e) {
 }
 
 fn test_config() -> config.Config {
-  config.new("client_id", "client_secret", "https://example.com/callback")
+  config.new(
+    client_id: "client_id",
+    client_secret: "client_secret",
+    redirect_uri: "https://example.com/callback",
+  )
 }
 
 fn find_header(

--- a/packages/vestibule_wisp/gleam.toml
+++ b/packages/vestibule_wisp/gleam.toml
@@ -13,3 +13,19 @@ gleam_http = ">= 4.3.0 and < 5.0.0"
 
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+# See root gleam.toml for rationale; these rules conflict with vestibule's
+# deliberate library patterns (public API exports, domain error mapping).
+[tools.glinter]
+# Strict lint: any warning fails the build. glinter only supports this
+# globally (no per-rule error severity), so label_possible is turned off
+# below to keep intentional unlabelled subject/pipe first-args from failing.
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Argument labels are encouraged but not enforced: many functions intentionally
+# leave their subject/pipe-receiver first arg unlabelled.
+label_possible = "off"
+unused_exports = "off"
+error_context_lost = "off"

--- a/packages/vestibule_wisp/manifest.toml
+++ b/packages/vestibule_wisp/manifest.toml
@@ -8,6 +8,7 @@ packages = [
   { name = "envoy", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "850DA9D29D2E5987735872A2B5C81035146D7FE19EFC486129E44440D03FD832" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
@@ -21,7 +22,9 @@ packages = [
   { name = "gleam_stdlib", version = "0.69.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "AAB0962BEBFAA67A2FBEE9EEE218B057756808DC9AF77430F5182C6115B3A315" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "glisten", version = "8.0.3", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "86B838196592D9EBDE7A1D2369AE3A51E568F7DD2D168706C463C42D17B95312" },
   { name = "gramps", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "8B7195978FBFD30B43DF791A8A272041B81E45D245314D7A41FC57237AA882A0" },
   { name = "houdini", version = "1.2.0", build_tools = ["gleam"], requirements = [], otp_app = "houdini", source = "hex", outer_checksum = "5DB1053F1AF828049C2B206D4403C18970ABEF5C18671CA3C2D2ED0DD64F6385" },
@@ -33,6 +36,7 @@ packages = [
   { name = "platform", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "platform", source = "hex", outer_checksum = "8339420A95AD89AAC0F82F4C3DB8DD401041742D6C3F46132A8739F6AEB75391" },
   { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
   { name = "tom", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "90791DA4AACE637E30081FE77049B8DB850FBC8CACC31515376BCC4E59BE1DD2" },
@@ -43,6 +47,7 @@ packages = [
 [requirements]
 gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }
 vestibule = { path = "../.." }
 wisp = { version = ">= 2.2.0 and < 3.0.0" }

--- a/packages/vestibule_wisp/src/vestibule_wisp.gleam
+++ b/packages/vestibule_wisp/src/vestibule_wisp.gleam
@@ -88,28 +88,34 @@ pub fn is_host_bound_cookie_name(name: String) -> Bool {
 /// Returns 404 if the provider is not registered.
 pub fn request_phase(
   req: Request,
-  reg: Registry(e),
-  provider: String,
-  state_store: StateStore,
+  reg reg: Registry(e),
+  provider provider: String,
+  state_store state_store: StateStore,
 ) -> Response {
-  request_phase_with_options(req, reg, provider, state_store, default_options())
+  request_phase_with_options(
+    req,
+    reg: reg,
+    provider: provider,
+    state_store: state_store,
+    options: default_options(),
+  )
 }
 
 /// Phase 1: Redirect user to the OAuth provider using custom middleware
 /// options.
 pub fn request_phase_with_options(
   req: Request,
-  reg: Registry(e),
-  provider: String,
-  state_store: StateStore,
-  options: Options,
+  reg reg: Registry(e),
+  provider provider: String,
+  state_store state_store: StateStore,
+  options options: Options,
 ) -> Response {
   case
     transport_flow.start_authorization(
       reg,
-      provider,
-      state_store,
-      options.session_ttl_seconds,
+      provider: provider,
+      store: state_store,
+      ttl_seconds: options.session_ttl_seconds,
     )
   {
     Error(transport_flow.UnknownProvider(_)) -> wisp.not_found()
@@ -143,37 +149,37 @@ pub fn request_phase_with_options(
 /// Returns 404 if the provider is not registered.
 pub fn callback_phase(
   req: Request,
-  reg: Registry(e),
-  provider: String,
-  state_store: StateStore,
-  on_success: fn(Auth) -> Response,
+  reg reg: Registry(e),
+  provider provider: String,
+  state_store state_store: StateStore,
+  on_success on_success: fn(Auth) -> Response,
 ) -> Response {
   callback_phase_with_options(
     req,
-    reg,
-    provider,
-    state_store,
-    on_success,
-    default_options(),
+    reg: reg,
+    provider: provider,
+    state_store: state_store,
+    on_success: on_success,
+    options: default_options(),
   )
 }
 
 /// Phase 2: Handle the OAuth callback using custom middleware options.
 pub fn callback_phase_with_options(
   req: Request,
-  reg: Registry(e),
-  provider: String,
-  state_store: StateStore,
-  on_success: fn(Auth) -> Response,
-  options: Options,
+  reg reg: Registry(e),
+  provider provider: String,
+  state_store state_store: StateStore,
+  on_success on_success: fn(Auth) -> Response,
+  options options: Options,
 ) -> Response {
   case
     callback_phase_auth_result_with_options(
       req,
-      reg,
-      provider,
-      state_store,
-      options,
+      reg: reg,
+      provider: provider,
+      state_store: state_store,
+      options: options,
     )
   {
     Ok(auth) -> on_success(auth)
@@ -191,16 +197,16 @@ pub fn callback_phase_with_options(
 /// success value or generated error response yourself.
 pub fn callback_phase_result(
   req: Request,
-  reg: Registry(e),
-  provider: String,
-  state_store: StateStore,
+  reg reg: Registry(e),
+  provider provider: String,
+  state_store state_store: StateStore,
 ) -> Result(Auth, Response) {
   callback_phase_result_with_options(
     req,
-    reg,
-    provider,
-    state_store,
-    default_options(),
+    reg: reg,
+    provider: provider,
+    state_store: state_store,
+    options: default_options(),
   )
 }
 
@@ -208,17 +214,17 @@ pub fn callback_phase_result(
 /// options.
 pub fn callback_phase_result_with_options(
   req: Request,
-  reg: Registry(e),
-  provider: String,
-  state_store: StateStore,
-  options: Options,
+  reg reg: Registry(e),
+  provider provider: String,
+  state_store state_store: StateStore,
+  options options: Options,
 ) -> Result(Auth, Response) {
   callback_phase_auth_result_with_options(
     req,
-    reg,
-    provider,
-    state_store,
-    options,
+    reg: reg,
+    provider: provider,
+    state_store: state_store,
+    options: options,
   )
   |> result.map_error(callback_error_response)
 }
@@ -230,16 +236,16 @@ pub fn callback_phase_result_with_options(
 /// parameter, and provider authentication failures without parsing responses.
 pub fn callback_phase_auth_result(
   req: Request,
-  reg: Registry(e),
-  provider: String,
-  state_store: StateStore,
+  reg reg: Registry(e),
+  provider provider: String,
+  state_store state_store: StateStore,
 ) -> Result(Auth, CallbackError(e)) {
   callback_phase_auth_result_with_options(
     req,
-    reg,
-    provider,
-    state_store,
-    default_options(),
+    reg: reg,
+    provider: provider,
+    state_store: state_store,
+    options: default_options(),
   )
 }
 
@@ -251,10 +257,10 @@ pub fn callback_phase_auth_result(
 /// valid in-flight login.
 pub fn callback_phase_auth_result_with_options(
   req: Request,
-  reg: Registry(e),
-  provider: String,
-  state_store: StateStore,
-  options: Options,
+  reg reg: Registry(e),
+  provider provider: String,
+  state_store state_store: StateStore,
+  options options: Options,
 ) -> Result(Auth, CallbackError(e)) {
   use strategy_config <- result.try(
     transport_flow.ensure_callback_provider(reg, provider)
@@ -270,9 +276,9 @@ pub fn callback_phase_auth_result_with_options(
 
   transport_flow.finish_callback(
     strategy_config,
-    state_store,
-    params,
-    session_id,
+    store: state_store,
+    params: params,
+    session_id: session_id,
   )
   |> result.map_error(map_callback_flow_error)
 }
@@ -286,26 +292,20 @@ fn get_callback_params(
   let query_params = wisp.get_query(req)
   case req.method {
     http.Post -> {
-      case wisp.read_body_bits(req) {
-        Ok(body_bits) -> {
-          case bit_array.to_string(body_bits) {
-            Ok(body_string) -> {
-              case uri.parse_query(body_string) {
-                Ok(body_params) -> {
-                  // Merge: body params take precedence over query params
-                  Ok(dict.merge(
-                    dict.from_list(query_params),
-                    dict.from_list(body_params),
-                  ))
-                }
-                Error(_) -> Error(InvalidCallbackParams)
-              }
-            }
-            Error(_) -> Error(InvalidCallbackParams)
-          }
-        }
-        Error(_) -> Error(InvalidCallbackParams)
-      }
+      use body_bits <- result.try(
+        wisp.read_body_bits(req)
+        |> result.replace_error(InvalidCallbackParams),
+      )
+      use body_string <- result.try(
+        bit_array.to_string(body_bits)
+        |> result.replace_error(InvalidCallbackParams),
+      )
+      use body_params <- result.try(
+        uri.parse_query(body_string)
+        |> result.replace_error(InvalidCallbackParams),
+      )
+      // Merge: body params take precedence over query params
+      Ok(dict.merge(dict.from_list(query_params), dict.from_list(body_params)))
     }
     _ -> Ok(dict.from_list(query_params))
   }

--- a/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
+++ b/packages/vestibule_wisp/test/vestibule_wisp_test.gleam
@@ -36,7 +36,7 @@ pub fn callback_phase_auth_result_missing_session_cookie_test() {
   let store = state_store.init_named("test_callback_missing_session_cookie")
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy(), test_config())
+    |> registry.register(strategy: test_strategy(), config: test_config())
 
   vestibule_wisp.callback_phase_auth_result(req, reg, "test", store)
   |> expect.to_equal(Error(vestibule_wisp.MissingSessionCookie))
@@ -70,7 +70,7 @@ pub fn request_phase_sets_host_bound_cookie_test() {
   let store = state_store.init_named("test_request_phase_host_bound_cookie")
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy(), test_config())
+    |> registry.register(strategy: test_strategy(), config: test_config())
   let req = simulate.request(http.Get, "/auth/test")
 
   let response = vestibule_wisp.request_phase(req, reg, "test", store)
@@ -89,13 +89,14 @@ pub fn request_phase_sets_host_bound_cookie_test() {
 
 pub fn callback_phase_auth_result_with_options_uses_cookie_name_test() {
   let store = state_store.init_named("test_callback_custom_cookie_name")
-  let session_id = state_store.store(store, "state", "verifier")
+  let session_id =
+    state_store.store(store, state: "state", code_verifier: "verifier")
   let req =
     simulate.request(http.Get, "/auth/test/callback?state=state&code=code")
     |> simulate.cookie("vestibule_session", session_id, wisp.Signed)
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy(), test_config())
+    |> registry.register(strategy: test_strategy(), config: test_config())
 
   vestibule_wisp.callback_phase_auth_result_with_options(
     req,
@@ -112,14 +113,15 @@ pub fn callback_phase_auth_result_with_options_uses_cookie_name_test() {
 
 pub fn callback_phase_auth_result_malformed_post_body_returns_invalid_params_test() {
   let store = state_store.init_named("test_callback_malformed_post_body")
-  let session_id = state_store.store(store, "state", "verifier")
+  let session_id =
+    state_store.store(store, state: "state", code_verifier: "verifier")
   let req =
     simulate.request(http.Post, "/auth/test/callback?state=state&code=code")
     |> simulate.bit_array_body(<<255>>)
     |> simulate.cookie("__Host-vestibule_session", session_id, wisp.Signed)
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy(), test_config())
+    |> registry.register(strategy: test_strategy(), config: test_config())
 
   vestibule_wisp.callback_phase_auth_result(req, reg, "test", store)
   |> expect.to_equal(Error(vestibule_wisp.InvalidCallbackParams))
@@ -127,7 +129,8 @@ pub fn callback_phase_auth_result_malformed_post_body_returns_invalid_params_tes
 
 pub fn callback_phase_auth_result_missing_state_does_not_consume_session_test() {
   let store = state_store.init_named("test_callback_missing_state_reusable")
-  let session_id = state_store.store(store, "state", "verifier")
+  let session_id =
+    state_store.store(store, state: "state", code_verifier: "verifier")
   let req_missing_state =
     simulate.request(http.Get, "/auth/test/callback?code=code")
     |> simulate.cookie("__Host-vestibule_session", session_id, wisp.Signed)
@@ -136,7 +139,7 @@ pub fn callback_phase_auth_result_missing_state_does_not_consume_session_test() 
     |> simulate.cookie("__Host-vestibule_session", session_id, wisp.Signed)
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy(), test_config())
+    |> registry.register(strategy: test_strategy(), config: test_config())
 
   vestibule_wisp.callback_phase_auth_result(
     req_missing_state,
@@ -193,23 +196,35 @@ fn leaky_error_strategy() -> Strategy(e) {
 }
 
 fn test_config() -> config.Config {
-  config.new("client_id", "client_secret", "https://example.com/callback")
+  config.new(
+    client_id: "client_id",
+    client_secret: "client_secret",
+    redirect_uri: "https://example.com/callback",
+  )
 }
 
 pub fn callback_phase_default_error_response_does_not_render_provider_details_test() {
   let store = state_store.init_named("test_callback_generic_error_html")
-  let session_id = state_store.store(store, "state", "verifier")
+  let session_id =
+    state_store.store(store, state: "state", code_verifier: "verifier")
   let req =
     simulate.request(http.Get, "/auth/test/callback?state=state&code=code")
     |> simulate.cookie("__Host-vestibule_session", session_id, wisp.Signed)
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(leaky_error_strategy(), test_config())
+    |> registry.register(
+      strategy: leaky_error_strategy(),
+      config: test_config(),
+    )
 
   let response =
-    vestibule_wisp.callback_phase(req, reg, "test", store, fn(_auth) {
-      wisp.html_response("success", 200)
-    })
+    vestibule_wisp.callback_phase(
+      req,
+      reg: reg,
+      provider: "test",
+      state_store: store,
+      on_success: fn(_auth) { wisp.html_response("success", 200) },
+    )
 
   response.status |> expect.to_equal(400)
   let body = case response.body {
@@ -224,13 +239,17 @@ pub fn callback_phase_default_error_response_does_not_render_provider_details_te
 
 pub fn callback_phase_auth_result_preserves_provider_error_details_test() {
   let store = state_store.init_named("test_callback_structured_error_details")
-  let session_id = state_store.store(store, "state", "verifier")
+  let session_id =
+    state_store.store(store, state: "state", code_verifier: "verifier")
   let req =
     simulate.request(http.Get, "/auth/test/callback?state=state&code=code")
     |> simulate.cookie("__Host-vestibule_session", session_id, wisp.Signed)
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(leaky_error_strategy(), test_config())
+    |> registry.register(
+      strategy: leaky_error_strategy(),
+      config: test_config(),
+    )
 
   vestibule_wisp.callback_phase_auth_result(req, reg, "test", store)
   |> expect.to_equal(

--- a/src/vestibule.gleam
+++ b/src/vestibule.gleam
@@ -34,7 +34,7 @@ import vestibule/strategy.{type Strategy}
 /// check it before calling `handle_callback`.
 pub fn authorize_url(
   strat: Strategy(e),
-  cfg: Config,
+  cfg cfg: Config,
 ) -> Result(AuthorizationRequest, AuthError(e)) {
   let csrf_state = state.generate()
   let code_verifier = pkce.generate_verifier()
@@ -45,9 +45,9 @@ pub fn authorize_url(
   }
   use base_url <- result.try(strategy.build_authorize_url(
     strat,
-    cfg,
-    scopes,
-    csrf_state,
+    cfg: cfg,
+    scopes: scopes,
+    state: csrf_state,
   ))
   let url = append_pkce_params(base_url, code_challenge)
   Ok(authorization_request.new(
@@ -72,10 +72,10 @@ pub fn authorize_url(
 /// before calling this function.
 pub fn handle_callback(
   strat: Strategy(e),
-  cfg: Config,
-  callback_params: Dict(String, String),
-  expected_state: String,
-  code_verifier: String,
+  cfg cfg: Config,
+  callback_params callback_params: Dict(String, String),
+  expected_state expected_state: String,
+  code_verifier code_verifier: String,
 ) -> Result(Auth, AuthError(e)) {
   // Extract state (needed for CSRF validation)
   use received_state <- result.try(
@@ -84,7 +84,10 @@ pub fn handle_callback(
   )
 
   // Validate state before surfacing any provider response details.
-  use _ <- result.try(state.validate(received_state, expected_state))
+  use _ <- result.try(state.validate(
+    received: received_state,
+    expected: expected_state,
+  ))
 
   // Check for provider errors before requiring code
   use _ <- result.try(check_provider_error(callback_params))
@@ -98,13 +101,17 @@ pub fn handle_callback(
   // Exchange code for credentials and provider-specific artifacts, passing the PKCE verifier
   use exchange <- result.try(strategy.exchange_code(
     strat,
-    cfg,
-    code,
-    option.Some(code_verifier),
+    cfg: cfg,
+    code: code,
+    code_verifier: option.Some(code_verifier),
   ))
 
   // Fetch user info
-  use user <- result.try(strategy.fetch_user(strat, cfg, exchange))
+  use user <- result.try(strategy.fetch_user(
+    strat,
+    cfg: cfg,
+    exchange: exchange,
+  ))
 
   // Assemble the Auth result
   Ok(Auth(
@@ -121,10 +128,10 @@ pub fn handle_callback(
 /// Delegates to the provider strategy so refresh semantics remain provider-owned.
 pub fn refresh_token(
   strat: Strategy(e),
-  cfg: Config,
-  refresh_tok: String,
+  cfg cfg: Config,
+  refresh_tok refresh_tok: String,
 ) -> Result(Credentials, AuthError(e)) {
-  strategy.refresh_token(strat, cfg, refresh_tok)
+  strategy.refresh_token(strat, cfg: cfg, refresh_tok: refresh_tok)
 }
 
 /// Check callback params for a provider error response.

--- a/src/vestibule/config.gleam
+++ b/src/vestibule/config.gleam
@@ -19,9 +19,9 @@ pub opaque type Config {
 
 /// Create a new config with the required fields and empty defaults.
 pub fn new(
-  client_id: String,
-  client_secret: String,
-  redirect_uri: String,
+  client_id client_id: String,
+  client_secret client_secret: String,
+  redirect_uri redirect_uri: String,
 ) -> Config {
   Config(
     client_id: client_id,

--- a/src/vestibule/oidc.gleam
+++ b/src/vestibule/oidc.gleam
@@ -15,6 +15,7 @@
 //// let strategy = oidc.strategy_from_config(config, "my-provider")
 //// ```
 
+import gleam/bool
 import gleam/dict
 import gleam/dynamic/decode
 import gleam/http
@@ -120,17 +121,17 @@ pub fn fetch_configuration(
 ) -> Result(OidcConfig, AuthError(e)) {
   use discovery_url <- result.try(discovery_url(issuer_url))
 
-  use r <- result.try(
+  use req <- result.try(
     request.to(discovery_url)
     |> result.map_error(fn(_) {
       error.ConfigError(reason: "Invalid discovery URL: " <> discovery_url)
     }),
   )
-  let r =
-    r
+  let req =
+    req
     |> request.set_header("accept", "application/json")
 
-  case httpc.send(r) {
+  case httpc.send(req) {
     Ok(response) -> {
       use body <- result.try(provider_support.check_response_status(response))
       use config <- result.try(parse_discovery_document(body))
@@ -364,10 +365,8 @@ pub fn parse_userinfo_response(
 // --- Internal helpers ---
 
 fn strip_trailing_slash(url: String) -> String {
-  case string.ends_with(url, "/") {
-    True -> string.drop_end(url, 1)
-    False -> url
-  }
+  use <- bool.guard(when: !string.ends_with(url, "/"), return: url)
+  string.drop_end(url, 1)
 }
 
 fn extract_hostname(url: String) -> String {
@@ -441,7 +440,7 @@ fn build_exchange_code_fn(
     }
     let body = uri.query_to_string(params)
 
-    use r <- result.try(
+    use req <- result.try(
       request.to(token_endpoint)
       |> result.map_error(fn(_) {
         error.ConfigError(
@@ -449,14 +448,14 @@ fn build_exchange_code_fn(
         )
       }),
     )
-    let r =
-      r
+    let req =
+      req
       |> request.set_method(http.Post)
       |> request.set_header("content-type", "application/x-www-form-urlencoded")
       |> request.set_header("accept", "application/json")
       |> request.set_body(body)
 
-    case httpc.send(r) {
+    case httpc.send(req) {
       Ok(response) -> {
         use body <- result.try(provider_support.check_response_status(response))
         parse_token_response(body)
@@ -506,7 +505,7 @@ fn build_refresh_token_fn(
         #("client_secret", config.client_secret(cfg)),
       ])
 
-    use r <- result.try(
+    use req <- result.try(
       request.to(token_endpoint)
       |> result.map_error(fn(_) {
         error.ConfigError(
@@ -514,14 +513,14 @@ fn build_refresh_token_fn(
         )
       }),
     )
-    let r =
-      r
+    let req =
+      req
       |> request.set_method(http.Post)
       |> request.set_header("content-type", "application/x-www-form-urlencoded")
       |> request.set_header("accept", "application/json")
       |> request.set_body(body)
 
-    case httpc.send(r) {
+    case httpc.send(req) {
       Ok(response) -> {
         use body <- result.try(provider_support.check_response_status(response))
         parse_token_response(body)

--- a/src/vestibule/provider_support.gleam
+++ b/src/vestibule/provider_support.gleam
@@ -1,5 +1,6 @@
 //// Stable helpers for OAuth provider implementations.
 
+import gleam/bool
 import gleam/dynamic/decode
 import gleam/http/request
 import gleam/http/response.{type Response}
@@ -20,21 +21,19 @@ import vestibule/credentials
 pub fn check_response_status(
   response: Response(String),
 ) -> Result(String, AuthError(e)) {
-  case response.status >= 200 && response.status < 300 {
-    True -> Ok(response.body)
-    False ->
-      Error(error.HttpError(
-        status: response.status,
-        body: safe_error_body(response.body),
-      ))
-  }
+  use <- bool.guard(
+    when: response.status < 200 || response.status >= 300,
+    return: Error(error.HttpError(
+      status: response.status,
+      body: safe_error_body(response.body),
+    )),
+  )
+  Ok(response.body)
 }
 
 fn safe_error_body(body: String) -> String {
-  case string.length(body) > 120 {
-    True -> string.slice(body, 0, 120)
-    False -> body
-  }
+  use <- bool.guard(when: string.length(body) <= 120, return: body)
+  string.slice(body, 0, 120)
 }
 
 /// Validate that a URL uses HTTPS.
@@ -133,10 +132,11 @@ fn is_non_public_host(host: String) -> Bool {
 }
 
 fn strip_ipv6_brackets(host: String) -> String {
-  case string.starts_with(host, "[") && string.ends_with(host, "]") {
-    True -> string.slice(host, 1, string.length(host) - 2)
-    False -> host
-  }
+  use <- bool.guard(
+    when: !{ string.starts_with(host, "[") && string.ends_with(host, "]") },
+    return: host,
+  )
+  string.slice(host, 1, string.length(host) - 2)
 }
 
 fn is_blocked_hostname(host: String) -> Bool {
@@ -186,24 +186,21 @@ fn is_non_public_ipv4(octets: #(Int, Int, Int, Int)) -> Bool {
 }
 
 fn is_non_public_ipv6(host: String) -> Bool {
-  case string.contains(host, ":") {
-    // Not an IPv6 literal; an ordinary DNS hostname we cannot classify here.
-    False -> False
-    True ->
-      // Loopback and unspecified
-      host == "::1"
-      || host == "::"
-      // Unique local addresses fc00::/7 (fc.. / fd..)
-      || string.starts_with(host, "fc")
-      || string.starts_with(host, "fd")
-      // Link-local fe80::/10 (fe8.. / fe9.. / fea.. / feb..)
-      || string.starts_with(host, "fe8")
-      || string.starts_with(host, "fe9")
-      || string.starts_with(host, "fea")
-      || string.starts_with(host, "feb")
-      // IPv4-mapped / IPv4-compatible addresses embedding a non-public IPv4
-      || embeds_non_public_ipv4(host)
-  }
+  // Not an IPv6 literal; an ordinary DNS hostname we cannot classify here.
+  use <- bool.guard(when: !string.contains(host, ":"), return: False)
+  // Loopback and unspecified
+  host == "::1"
+  || host == "::"
+  // Unique local addresses fc00::/7 (fc.. / fd..)
+  || string.starts_with(host, "fc")
+  || string.starts_with(host, "fd")
+  // Link-local fe80::/10 (fe8.. / fe9.. / fea.. / feb..)
+  || string.starts_with(host, "fe8")
+  || string.starts_with(host, "fe9")
+  || string.starts_with(host, "fea")
+  || string.starts_with(host, "feb")
+  // IPv4-mapped / IPv4-compatible addresses embedding a non-public IPv4
+  || embeds_non_public_ipv4(host)
 }
 
 fn embeds_non_public_ipv4(host: String) -> Bool {

--- a/src/vestibule/registry.gleam
+++ b/src/vestibule/registry.gleam
@@ -40,8 +40,8 @@ pub fn new() -> Registry(e) {
 /// genuinely need to overwrite an entry should use `register_or_replace`.
 pub fn register(
   registry: Registry(e),
-  strategy: Strategy(e),
-  config: Config,
+  strategy strategy: Strategy(e),
+  config config: Config,
 ) -> Result(Registry(e), RegistryError) {
   let name = strategy.provider(strategy)
   case dict.has_key(registry.providers, name) {
@@ -63,8 +63,8 @@ pub fn register(
 /// overwrites a previously registered provider.
 pub fn register_or_replace(
   registry: Registry(e),
-  strategy: Strategy(e),
-  config: Config,
+  strategy strategy: Strategy(e),
+  config config: Config,
 ) -> Registry(e) {
   Registry(
     providers: dict.insert(registry.providers, strategy.provider(strategy), #(
@@ -77,7 +77,7 @@ pub fn register_or_replace(
 /// Look up a provider by name.
 pub fn get(
   registry: Registry(e),
-  provider: String,
+  provider provider: String,
 ) -> Result(#(Strategy(e), Config), Nil) {
   dict.get(registry.providers, provider)
 }

--- a/src/vestibule/state.gleam
+++ b/src/vestibule/state.gleam
@@ -3,6 +3,7 @@
 //// must be echoed back unchanged on the callback.
 
 import gleam/bit_array
+import gleam/bool
 import gleam/crypto
 import gleam/string
 
@@ -18,19 +19,18 @@ pub fn generate() -> String {
 /// Validate a received state parameter against the expected value.
 /// Uses constant-time comparison to prevent timing attacks.
 pub fn validate(
-  received: String,
-  expected: String,
+  received received: String,
+  expected expected: String,
 ) -> Result(Nil, AuthError(e)) {
-  case is_blank(received) || is_blank(expected) {
-    True -> Error(StateMismatch)
-    False -> {
-      let received_bits = <<received:utf8>>
-      let expected_bits = <<expected:utf8>>
-      case crypto.secure_compare(received_bits, expected_bits) {
-        True -> Ok(Nil)
-        False -> Error(StateMismatch)
-      }
-    }
+  use <- bool.guard(
+    when: is_blank(received) || is_blank(expected),
+    return: Error(StateMismatch),
+  )
+  let received_bits = <<received:utf8>>
+  let expected_bits = <<expected:utf8>>
+  case crypto.secure_compare(received_bits, expected_bits) {
+    True -> Ok(Nil)
+    False -> Error(StateMismatch)
   }
 }
 

--- a/src/vestibule/state_store.gleam
+++ b/src/vestibule/state_store.gleam
@@ -77,10 +77,11 @@ pub fn try_init_named(name: String) -> Result(StateStore, StateStoreError) {
 /// Store a CSRF state value and PKCE code verifier, returning a session ID.
 pub fn store(
   table: StateStore,
-  state: String,
-  code_verifier: String,
+  state state: String,
+  code_verifier code_verifier: String,
 ) -> String {
-  let assert Ok(session_id) = try_store(table, state, code_verifier)
+  let assert Ok(session_id) =
+    try_store(table, state: state, code_verifier: code_verifier)
     as "vestibule failed to store OAuth session state"
   session_id
 }
@@ -88,19 +89,24 @@ pub fn store(
 /// Try to store a CSRF state value and PKCE code verifier, returning a session ID.
 pub fn try_store(
   table: StateStore,
-  state: String,
-  code_verifier: String,
+  state state: String,
+  code_verifier code_verifier: String,
 ) -> Result(String, StateStoreError) {
-  try_store_with_ttl(table, state, code_verifier, default_ttl_seconds)
+  try_store_with_ttl(
+    table,
+    state: state,
+    code_verifier: code_verifier,
+    ttl_seconds: default_ttl_seconds,
+  )
 }
 
 /// Try to store a CSRF state value and PKCE verifier with a TTL, returning a
 /// session ID.
 pub fn try_store_with_ttl(
   table: StateStore,
-  state: String,
-  code_verifier: String,
-  ttl_seconds: Int,
+  state state: String,
+  code_verifier code_verifier: String,
+  ttl_seconds ttl_seconds: Int,
 ) -> Result(String, StateStoreError) {
   use _ <- result.try(
     cleanup_expired(table.table, timestamp.system_time())
@@ -151,8 +157,8 @@ pub fn peek(
       case validate_session(session) {
         Ok(value) -> Ok(value)
         Error(Nil) -> {
-          let _ = delete_key(table.table, session_id)
-          let _ = cleanup_expired(table.table, timestamp.system_time())
+          let _deleted = delete_key(table.table, session_id)
+          let _cleaned = cleanup_expired(table.table, timestamp.system_time())
           Error(Nil)
         }
       }

--- a/src/vestibule/strategy.gleam
+++ b/src/vestibule/strategy.gleam
@@ -160,9 +160,9 @@ pub fn default_scopes(strat: Strategy(e)) -> List(String) {
 /// Build the provider's authorization URL.
 pub fn build_authorize_url(
   strat: Strategy(e),
-  cfg: Config,
-  scopes: List(String),
-  state: String,
+  cfg cfg: Config,
+  scopes scopes: List(String),
+  state state: String,
 ) -> Result(String, AuthError(e)) {
   strat.authorize_url(cfg, scopes, state)
 }
@@ -172,9 +172,9 @@ pub fn build_authorize_url(
 /// authorization request.
 pub fn exchange_code(
   strat: Strategy(e),
-  cfg: Config,
-  code: String,
-  code_verifier: Option(String),
+  cfg cfg: Config,
+  code code: String,
+  code_verifier code_verifier: Option(String),
 ) -> Result(ExchangeResult, AuthError(e)) {
   strat.exchange_code(cfg, code, code_verifier)
 }
@@ -182,8 +182,8 @@ pub fn exchange_code(
 /// Refresh credentials using a refresh token.
 pub fn refresh_token(
   strat: Strategy(e),
-  cfg: Config,
-  refresh_tok: String,
+  cfg cfg: Config,
+  refresh_tok refresh_tok: String,
 ) -> Result(credentials.Credentials, AuthError(e)) {
   strat.refresh_token(cfg, refresh_tok)
 }
@@ -191,8 +191,8 @@ pub fn refresh_token(
 /// Fetch user info using the obtained exchange result.
 pub fn fetch_user(
   strat: Strategy(e),
-  cfg: Config,
-  exchange: ExchangeResult,
+  cfg cfg: Config,
+  exchange exchange: ExchangeResult,
 ) -> Result(UserResult, AuthError(e)) {
   strat.fetch_user(cfg, exchange)
 }

--- a/src/vestibule/transport_flow.gleam
+++ b/src/vestibule/transport_flow.gleam
@@ -30,24 +30,24 @@ pub type CallbackFlowError(e) {
 /// Generate an authorization URL and store the expected state/verifier.
 pub fn start_authorization(
   provider_registry: Registry(e),
-  provider: String,
-  store: StateStore,
-  ttl_seconds: Int,
+  provider provider: String,
+  store store: StateStore,
+  ttl_seconds ttl_seconds: Int,
 ) -> Result(#(String, String), RequestFlowError(e)) {
   use #(strategy, config) <- result.try(
-    registry.get(provider_registry, provider)
+    registry.get(provider_registry, provider: provider)
     |> result.map_error(fn(_) { UnknownProvider(provider) }),
   )
   use auth_request <- result.try(
-    vestibule.authorize_url(strategy, config)
+    vestibule.authorize_url(strategy, cfg: config)
     |> result.map_error(AuthFailed),
   )
   use session_id <- result.try(
     state_store.try_store_with_ttl(
       store,
-      authorization_request.state(auth_request),
-      authorization_request.code_verifier(auth_request),
-      ttl_seconds,
+      state: authorization_request.state(auth_request),
+      code_verifier: authorization_request.code_verifier(auth_request),
+      ttl_seconds: ttl_seconds,
     )
     |> result.map_error(StoreFailed),
   )
@@ -66,7 +66,7 @@ pub fn ensure_callback_provider(
   provider_registry: Registry(e),
   provider: String,
 ) -> Result(#(Strategy(e), Config), CallbackFlowError(e)) {
-  registry.get(provider_registry, provider)
+  registry.get(provider_registry, provider: provider)
   |> result.map_error(fn(_) { CallbackUnknownProvider(provider) })
 }
 
@@ -76,9 +76,9 @@ pub fn ensure_callback_provider(
 /// reuse the provider lookup instead of querying the registry again.
 pub fn finish_callback(
   strategy_config: #(Strategy(e), Config),
-  store: StateStore,
-  params: Dict(String, String),
-  session_id: String,
+  store store: StateStore,
+  params params: Dict(String, String),
+  session_id session_id: String,
 ) -> Result(Auth, CallbackFlowError(e)) {
   let #(strategy, config) = strategy_config
 
@@ -95,7 +95,7 @@ pub fn finish_callback(
   )
 
   use _ <- result.try(
-    state.validate(received_state, expected_state)
+    state.validate(received: received_state, expected: expected_state)
     |> result.map_error(CallbackAuthFailed),
   )
 
@@ -106,10 +106,10 @@ pub fn finish_callback(
 
   vestibule.handle_callback(
     strategy,
-    config,
-    params,
-    expected_state,
-    code_verifier,
+    cfg: config,
+    callback_params: params,
+    expected_state: expected_state,
+    code_verifier: code_verifier,
   )
   |> result.map_error(CallbackAuthFailed)
 }

--- a/test/vestibule/config_test.gleam
+++ b/test/vestibule/config_test.gleam
@@ -4,7 +4,12 @@ import vestibule/config
 import vestibule/error
 
 pub fn new_creates_config_with_empty_defaults_test() {
-  let c = config.new("id", "secret", "http://localhost/callback")
+  let c =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/callback",
+    )
   config.client_id(c) |> expect.to_equal("id")
   config.client_secret(c) |> expect.to_equal("secret")
   config.redirect_uri(c) |> expect.to_equal("http://localhost/callback")
@@ -14,14 +19,22 @@ pub fn new_creates_config_with_empty_defaults_test() {
 
 pub fn with_scopes_replaces_scopes_test() {
   let c =
-    config.new("id", "secret", "http://localhost/callback")
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/callback",
+    )
     |> config.with_scopes(["user:email", "read:org"])
   config.scopes(c) |> expect.to_equal(["user:email", "read:org"])
 }
 
 pub fn with_extra_params_adds_params_test() {
   let assert Ok(c) =
-    config.new("id", "secret", "http://localhost/callback")
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/callback",
+    )
     |> config.with_extra_params([#("allow_signup", "false")])
   config.extra_params(c)
   |> expect.to_equal(dict.from_list([#("allow_signup", "false")]))
@@ -39,7 +52,11 @@ pub fn with_extra_params_rejects_reserved_authorization_params_test() {
 
 fn assert_reserved_param_rejected(param: String) {
   let result =
-    config.new("id", "secret", "http://localhost/callback")
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/callback",
+    )
     |> config.with_extra_params([#(param, "attacker-value")])
 
   case result {

--- a/test/vestibule/oidc_test.gleam
+++ b/test/vestibule/oidc_test.gleam
@@ -508,13 +508,17 @@ pub fn strategy_from_config_authorize_url_test() {
   let oidc_config = example_config()
   let strat = oidc.strategy_from_config(oidc_config, "example")
   let conf =
-    config.new("my-client-id", "my-secret", "http://localhost/callback")
+    config.new(
+      client_id: "my-client-id",
+      client_secret: "my-secret",
+      redirect_uri: "http://localhost/callback",
+    )
   let result =
     strategy.build_authorize_url(
       strat,
-      conf,
-      ["openid", "profile"],
-      "test-state",
+      cfg: conf,
+      scopes: ["openid", "profile"],
+      state: "test-state",
     )
   let assert Ok(url) = result
   // Verify all expected query parameters are in the URL
@@ -538,10 +542,19 @@ pub fn strategy_from_config_authorize_url_with_extra_params_test() {
     )
   let strat = oidc.strategy_from_config(oidc_config, "example")
   let assert Ok(conf) =
-    config.new("client-id", "secret", "http://localhost/cb")
+    config.new(
+      client_id: "client-id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/cb",
+    )
     |> config.with_extra_params([#("prompt", "consent")])
   let assert Ok(url) =
-    strategy.build_authorize_url(strat, conf, ["openid"], "state-123")
+    strategy.build_authorize_url(
+      strat,
+      cfg: conf,
+      scopes: ["openid"],
+      state: "state-123",
+    )
   { string.contains(url, "prompt=consent") } |> expect.to_be_true()
 }
 
@@ -555,9 +568,19 @@ pub fn strategy_from_config_invalid_redirect_uri_returns_error_test() {
       scopes_supported: ["openid"],
     )
   let strat = oidc.strategy_from_config(oidc_config, "example")
-  let conf = config.new("client-id", "secret", "not a uri")
+  let conf =
+    config.new(
+      client_id: "client-id",
+      client_secret: "secret",
+      redirect_uri: "not a uri",
+    )
   let _ =
-    strategy.build_authorize_url(strat, conf, ["openid"], "state-123")
+    strategy.build_authorize_url(
+      strat,
+      cfg: conf,
+      scopes: ["openid"],
+      state: "state-123",
+    )
     |> expect.to_be_error()
   Nil
 }

--- a/test/vestibule/registry_test.gleam
+++ b/test/vestibule/registry_test.gleam
@@ -23,7 +23,11 @@ fn test_strategy(name: String) -> Strategy(e) {
 }
 
 fn test_config() -> config.Config {
-  config.new("client_id", "client_secret", "https://example.com/callback")
+  config.new(
+    client_id: "client_id",
+    client_secret: "client_secret",
+    redirect_uri: "https://example.com/callback",
+  )
 }
 
 pub fn new_registry_has_no_providers_test() {
@@ -37,14 +41,14 @@ pub fn register_and_get_provider_test() {
   let cfg = test_config()
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(strategy, cfg)
-  let assert Ok(#(s, _c)) = registry.get(reg, "github")
+    |> registry.register(strategy: strategy, config: cfg)
+  let assert Ok(#(s, _c)) = registry.get(reg, provider: "github")
   strategy.provider(s) |> expect.to_equal("github")
 }
 
 pub fn get_unknown_provider_returns_error_test() {
   let reg = registry.new()
-  registry.get(reg, "unknown")
+  registry.get(reg, provider: "unknown")
   |> expect.to_be_error()
   |> expect.to_equal(Nil)
 }
@@ -52,10 +56,16 @@ pub fn get_unknown_provider_returns_error_test() {
 pub fn providers_returns_registered_names_test() {
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy("github"), test_config())
+    |> registry.register(
+      strategy: test_strategy("github"),
+      config: test_config(),
+    )
   let assert Ok(reg) =
     reg
-    |> registry.register(test_strategy("microsoft"), test_config())
+    |> registry.register(
+      strategy: test_strategy("microsoft"),
+      config: test_config(),
+    )
   let names = registry.providers(reg)
   names |> list.contains("github") |> expect.to_be_true()
   names |> list.contains("microsoft") |> expect.to_be_true()
@@ -65,52 +75,73 @@ pub fn providers_returns_registered_names_test() {
 pub fn register_duplicate_provider_is_rejected_test() {
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy("github"), test_config())
+    |> registry.register(
+      strategy: test_strategy("github"),
+      config: test_config(),
+    )
 
   reg
-  |> registry.register(test_strategy("github"), test_config())
+  |> registry.register(strategy: test_strategy("github"), config: test_config())
   |> expect.to_be_error()
   |> expect.to_equal(registry.DuplicateProvider("github"))
 }
 
 pub fn register_duplicate_does_not_replace_trusted_entry_test() {
   let trusted_cfg =
-    config.new("trusted_id", "trusted_secret", "https://example.com/callback")
+    config.new(
+      client_id: "trusted_id",
+      client_secret: "trusted_secret",
+      redirect_uri: "https://example.com/callback",
+    )
   let attacker_cfg =
     config.new(
-      "attacker_id",
-      "attacker_secret",
-      "https://evil.example/callback",
+      client_id: "attacker_id",
+      client_secret: "attacker_secret",
+      redirect_uri: "https://evil.example/callback",
     )
 
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy("github"), trusted_cfg)
+    |> registry.register(strategy: test_strategy("github"), config: trusted_cfg)
 
   // A second registration under the same name must not overwrite the trusted
   // entry.
   let _ =
     reg
-    |> registry.register(test_strategy("github"), attacker_cfg)
+    |> registry.register(
+      strategy: test_strategy("github"),
+      config: attacker_cfg,
+    )
 
-  let assert Ok(#(_s, c)) = registry.get(reg, "github")
+  let assert Ok(#(_s, c)) = registry.get(reg, provider: "github")
   config.client_id(c) |> expect.to_equal("trusted_id")
 }
 
 pub fn register_or_replace_overwrites_existing_test() {
   let first_cfg =
-    config.new("first_id", "first_secret", "https://example.com/callback")
+    config.new(
+      client_id: "first_id",
+      client_secret: "first_secret",
+      redirect_uri: "https://example.com/callback",
+    )
   let second_cfg =
-    config.new("second_id", "second_secret", "https://example.com/callback")
+    config.new(
+      client_id: "second_id",
+      client_secret: "second_secret",
+      redirect_uri: "https://example.com/callback",
+    )
 
   let assert Ok(reg) =
     registry.new()
-    |> registry.register(test_strategy("github"), first_cfg)
+    |> registry.register(strategy: test_strategy("github"), config: first_cfg)
   let reg =
     reg
-    |> registry.register_or_replace(test_strategy("github"), second_cfg)
+    |> registry.register_or_replace(
+      strategy: test_strategy("github"),
+      config: second_cfg,
+    )
 
-  let assert Ok(#(_s, c)) = registry.get(reg, "github")
+  let assert Ok(#(_s, c)) = registry.get(reg, provider: "github")
   config.client_id(c) |> expect.to_equal("second_id")
   registry.providers(reg) |> list.length |> expect.to_equal(1)
 }

--- a/test/vestibule/security_test.gleam
+++ b/test/vestibule/security_test.gleam
@@ -78,13 +78,13 @@ fn test_strategy() -> Strategy(e) {
 
 /// Security: empty state values must always be rejected.
 pub fn state_validate_rejects_both_empty_test() {
-  state.validate("", "")
+  state.validate(received: "", expected: "")
   |> expect.to_equal(Error(error.StateMismatch))
 }
 
 /// Security: whitespace-only state values must be rejected.
 pub fn state_validate_rejects_whitespace_only_test() {
-  state.validate("   ", "   ")
+  state.validate(received: "   ", expected: "   ")
   |> expect.to_equal(Error(error.StateMismatch))
 }
 
@@ -125,7 +125,7 @@ pub fn state_validate_rejects_near_miss_test() {
   // Flip the last character
   let prefix = string.drop_end(s, 1)
   let tampered = prefix <> "X"
-  state.validate(tampered, s)
+  state.validate(received: tampered, expected: s)
   |> expect.to_equal(Error(error.StateMismatch))
 }
 
@@ -133,7 +133,7 @@ pub fn state_validate_rejects_near_miss_test() {
 pub fn state_validate_rejects_swapped_values_test() {
   let a = state.generate()
   let b = state.generate()
-  state.validate(a, b)
+  state.validate(received: a, expected: b)
   |> expect.to_equal(Error(error.StateMismatch))
 }
 
@@ -188,8 +188,13 @@ pub fn pkce_different_verifiers_produce_different_challenges_test() {
 /// No code path should produce a URL without code_challenge.
 pub fn authorize_url_always_includes_pkce_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "https://localhost/cb")
-  let assert Ok(auth_req) = vestibule.authorize_url(strat, conf)
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "https://localhost/cb",
+    )
+  let assert Ok(auth_req) = vestibule.authorize_url(strat, cfg: conf)
   let url = authorization_request.url(auth_req)
   { string.contains(url, "code_challenge=") } |> expect.to_be_true()
   { string.contains(url, "code_challenge_method=S256") } |> expect.to_be_true()
@@ -198,9 +203,14 @@ pub fn authorize_url_always_includes_pkce_test() {
 /// Security: authorize_url state and verifier must differ on each call.
 pub fn authorize_url_produces_fresh_state_and_verifier_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "https://localhost/cb")
-  let assert Ok(req1) = vestibule.authorize_url(strat, conf)
-  let assert Ok(req2) = vestibule.authorize_url(strat, conf)
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "https://localhost/cb",
+    )
+  let assert Ok(req1) = vestibule.authorize_url(strat, cfg: conf)
+  let assert Ok(req2) = vestibule.authorize_url(strat, cfg: conf)
   { authorization_request.state(req1) != authorization_request.state(req2) }
   |> expect.to_be_true()
   {
@@ -218,27 +228,60 @@ pub fn authorize_url_produces_fresh_state_and_verifier_test() {
 /// server-side operations (code exchange, user fetch).
 pub fn callback_rejects_state_mismatch_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "https://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "https://localhost/cb",
+    )
   let params =
     dict.from_list([#("code", "valid_code"), #("state", "attacker_state")])
-  vestibule.handle_callback(strat, conf, params, "real_state", "verifier")
+  vestibule.handle_callback(
+    strat,
+    cfg: conf,
+    callback_params: params,
+    expected_state: "real_state",
+    code_verifier: "verifier",
+  )
   |> expect.to_equal(Error(error.StateMismatch))
 }
 
 /// Security: missing state parameter must be rejected.
 pub fn callback_rejects_missing_state_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "https://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "https://localhost/cb",
+    )
   let params = dict.from_list([#("code", "valid_code")])
-  vestibule.handle_callback(strat, conf, params, "expected", "verifier")
+  vestibule.handle_callback(
+    strat,
+    cfg: conf,
+    callback_params: params,
+    expected_state: "expected",
+    code_verifier: "verifier",
+  )
   |> expect.to_equal(Error(error.MissingCallbackParam("state")))
 }
 
 /// Security: empty callback params must be rejected.
 pub fn callback_rejects_empty_params_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "https://localhost/cb")
-  vestibule.handle_callback(strat, conf, dict.new(), "expected", "verifier")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "https://localhost/cb",
+    )
+  vestibule.handle_callback(
+    strat,
+    cfg: conf,
+    callback_params: dict.new(),
+    expected_state: "expected",
+    code_verifier: "verifier",
+  )
   |> expect.to_equal(Error(error.MissingCallbackParam("state")))
 }
 
@@ -247,7 +290,12 @@ pub fn callback_rejects_empty_params_test() {
 /// the library should propagate the ProviderError, not a generic message.
 pub fn callback_detects_provider_error_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "https://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "https://localhost/cb",
+    )
   let state_val = "matching_state"
   let params =
     dict.from_list([
@@ -255,7 +303,13 @@ pub fn callback_detects_provider_error_test() {
       #("error", "access_denied"),
       #("error_description", "User denied access"),
     ])
-  vestibule.handle_callback(strat, conf, params, state_val, "verifier")
+  vestibule.handle_callback(
+    strat,
+    cfg: conf,
+    callback_params: params,
+    expected_state: state_val,
+    code_verifier: "verifier",
+  )
   |> expect.to_be_error()
   |> expect.to_equal(error.ProviderError(
     code: "access_denied",
@@ -266,7 +320,12 @@ pub fn callback_detects_provider_error_test() {
 
 pub fn callback_preserves_provider_error_uri_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "https://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "https://localhost/cb",
+    )
   let state_val = "matching_state"
   let params =
     dict.from_list([
@@ -275,7 +334,13 @@ pub fn callback_preserves_provider_error_uri_test() {
       #("error_description", "User denied access"),
       #("error_uri", "https://example.com/access-denied"),
     ])
-  vestibule.handle_callback(strat, conf, params, state_val, "verifier")
+  vestibule.handle_callback(
+    strat,
+    cfg: conf,
+    callback_params: params,
+    expected_state: state_val,
+    code_verifier: "verifier",
+  )
   |> expect.to_be_error()
   |> expect.to_equal(error.ProviderError(
     code: "access_denied",
@@ -287,21 +352,37 @@ pub fn callback_preserves_provider_error_uri_test() {
 /// Security: state validation must happen before provider errors are surfaced.
 pub fn callback_rejects_provider_error_when_state_mismatch_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "https://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "https://localhost/cb",
+    )
   let params =
     dict.from_list([
       #("state", "attacker_state"),
       #("error", "access_denied"),
       #("error_description", "User denied access"),
     ])
-  vestibule.handle_callback(strat, conf, params, "expected_state", "verifier")
+  vestibule.handle_callback(
+    strat,
+    cfg: conf,
+    callback_params: params,
+    expected_state: "expected_state",
+    code_verifier: "verifier",
+  )
   |> expect.to_equal(Error(error.StateMismatch))
 }
 
 /// Security: extra unexpected parameters should not cause crashes.
 pub fn callback_ignores_extra_params_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "https://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "https://localhost/cb",
+    )
   let state_val = "test_state"
   let params =
     dict.from_list([
@@ -311,7 +392,13 @@ pub fn callback_ignores_extra_params_test() {
       #("another", "<script>alert(1)</script>"),
     ])
   let result =
-    vestibule.handle_callback(strat, conf, params, state_val, "verifier")
+    vestibule.handle_callback(
+      strat,
+      cfg: conf,
+      callback_params: params,
+      expected_state: state_val,
+      code_verifier: "verifier",
+    )
   let _ = result |> expect.to_be_ok()
   Nil
 }
@@ -468,10 +555,10 @@ pub fn oidc_rejects_unverified_email_test() {
 /// Security: null bytes in state parameter must not bypass validation.
 pub fn state_validate_handles_null_bytes_test() {
   let _ =
-    state.validate("abc\u{0000}def", "abc\u{0000}def")
+    state.validate(received: "abc\u{0000}def", expected: "abc\u{0000}def")
     |> expect.to_be_ok()
 
-  state.validate("abc\u{0000}def", "abcXdef")
+  state.validate(received: "abc\u{0000}def", expected: "abcXdef")
   |> expect.to_equal(Error(error.StateMismatch))
 }
 
@@ -481,7 +568,7 @@ pub fn state_validate_handles_null_bytes_test() {
 pub fn state_validate_is_byte_level_comparison_test() {
   // These are the same visual character but different byte sequences
   // e-acute: U+00E9 (single codepoint) vs e + combining acute U+0065 U+0301
-  state.validate("\u{00E9}", "e\u{0301}")
+  state.validate(received: "\u{00E9}", expected: "e\u{0301}")
   |> expect.to_equal(Error(error.StateMismatch))
 }
 
@@ -489,10 +576,10 @@ pub fn state_validate_is_byte_level_comparison_test() {
 pub fn state_validate_handles_long_values_test() {
   let long = string.repeat("a", 10_000)
   let _ =
-    state.validate(long, long)
+    state.validate(received: long, expected: long)
     |> expect.to_be_ok()
 
-  state.validate(long, long <> "x")
+  state.validate(received: long, expected: long <> "x")
   |> expect.to_equal(Error(error.StateMismatch))
 }
 

--- a/test/vestibule/state_store_test.gleam
+++ b/test/vestibule/state_store_test.gleam
@@ -6,7 +6,8 @@ pub fn store_and_retrieve_state_and_verifier_test() {
   let table = state_store.init_named("test_store_retrieve")
   let state = "test-csrf-state-value"
   let verifier = "test-pkce-code-verifier"
-  let session_id = state_store.store(table, state, verifier)
+  let session_id =
+    state_store.store(table, state: state, code_verifier: verifier)
   state_store.consume(table, session_id)
   |> expect.to_be_ok()
   |> expect.to_equal(#(state, verifier))
@@ -15,7 +16,11 @@ pub fn store_and_retrieve_state_and_verifier_test() {
 pub fn retrieve_deletes_after_use_test() {
   let table = state_store.init_named("test_delete_after_use")
   let session_id =
-    state_store.store(table, "one-time-state", "one-time-verifier")
+    state_store.store(
+      table,
+      state: "one-time-state",
+      code_verifier: "one-time-verifier",
+    )
   let _ = state_store.consume(table, session_id)
   state_store.consume(table, session_id)
   |> expect.to_be_error()
@@ -24,7 +29,11 @@ pub fn retrieve_deletes_after_use_test() {
 pub fn consume_deletes_after_use_test() {
   let table = state_store.init_named("test_consume_delete_after_use")
   let session_id =
-    state_store.store(table, "one-time-state", "one-time-verifier")
+    state_store.store(
+      table,
+      state: "one-time-state",
+      code_verifier: "one-time-verifier",
+    )
   state_store.consume(table, session_id)
   |> expect.to_be_ok()
   state_store.consume(table, session_id)
@@ -53,7 +62,8 @@ pub fn try_store_returns_session_id_and_retrievable_value_test() {
   let assert Ok(table) = state_store.try_init_named("vestibule_try_store_test")
   let state = "state"
   let verifier = "verifier"
-  let assert Ok(session_id) = state_store.try_store(table, state, verifier)
+  let assert Ok(session_id) =
+    state_store.try_store(table, state: state, code_verifier: verifier)
 
   { string.length(session_id) > 0 } |> expect.to_be_true()
   state_store.consume(table, session_id)
@@ -67,7 +77,12 @@ pub fn try_store_with_ttl_stores_retrievable_value_test() {
   let state = "state"
   let verifier = "verifier"
   let assert Ok(session_id) =
-    state_store.try_store_with_ttl(table, state, verifier, 600)
+    state_store.try_store_with_ttl(
+      table,
+      state: state,
+      code_verifier: verifier,
+      ttl_seconds: 600,
+    )
 
   state_store.consume(table, session_id)
   |> expect.to_be_ok()
@@ -78,7 +93,12 @@ pub fn retrieve_consumes_expired_session_test() {
   let assert Ok(table) =
     state_store.try_init_named("vestibule_expired_session_test")
   let assert Ok(session_id) =
-    state_store.try_store_with_ttl(table, "state", "verifier", 0)
+    state_store.try_store_with_ttl(
+      table,
+      state: "state",
+      code_verifier: "verifier",
+      ttl_seconds: 0,
+    )
 
   state_store.consume(table, session_id)
   |> expect.to_be_error()
@@ -90,12 +110,22 @@ pub fn storing_new_session_removes_expired_sessions_test() {
   let name = "vestibule_cleanup_expired_session_test"
   let assert Ok(table) = state_store.try_init_named(name)
   let assert Ok(_) =
-    state_store.try_store_with_ttl(table, "expired-state", "verifier", 0)
+    state_store.try_store_with_ttl(
+      table,
+      state: "expired-state",
+      code_verifier: "verifier",
+      ttl_seconds: 0,
+    )
 
   count_store_entries(name) |> expect.to_equal(1)
 
   let assert Ok(_) =
-    state_store.try_store_with_ttl(table, "fresh-state", "verifier", 600)
+    state_store.try_store_with_ttl(
+      table,
+      state: "fresh-state",
+      code_verifier: "verifier",
+      ttl_seconds: 600,
+    )
 
   count_store_entries(name) |> expect.to_equal(1)
 }

--- a/test/vestibule/state_test.gleam
+++ b/test/vestibule/state_test.gleam
@@ -16,21 +16,21 @@ pub fn generate_produces_unique_values_test() {
 
 pub fn validate_accepts_matching_state_test() {
   let s = state.generate()
-  state.validate(s, s)
+  state.validate(received: s, expected: s)
   |> expect.to_be_ok()
 }
 
 pub fn validate_rejects_mismatched_state_test() {
-  state.validate("abc123", "def456")
+  state.validate(received: "abc123", expected: "def456")
   |> expect.to_equal(Error(error.StateMismatch))
 }
 
 pub fn validate_rejects_empty_state_test() {
-  state.validate("", "some-state")
+  state.validate(received: "", expected: "some-state")
   |> expect.to_equal(Error(error.StateMismatch))
 }
 
 pub fn validate_rejects_whitespace_only_state_test() {
-  state.validate("   ", "   ")
+  state.validate(received: "   ", expected: "   ")
   |> expect.to_equal(Error(error.StateMismatch))
 }

--- a/test/vestibule_test.gleam
+++ b/test/vestibule_test.gleam
@@ -137,17 +137,31 @@ fn fragment_strategy() -> Strategy(e) {
       )
     },
     exchange_code: fn(cfg, code, verifier) {
-      strategy.exchange_code(base, cfg, code, verifier)
+      strategy.exchange_code(
+        base,
+        cfg: cfg,
+        code: code,
+        code_verifier: verifier,
+      )
     },
-    refresh_token: fn(cfg, tok) { strategy.refresh_token(base, cfg, tok) },
-    fetch_user: fn(cfg, exchange) { strategy.fetch_user(base, cfg, exchange) },
+    refresh_token: fn(cfg, tok) {
+      strategy.refresh_token(base, cfg: cfg, refresh_tok: tok)
+    },
+    fetch_user: fn(cfg, exchange) {
+      strategy.fetch_user(base, cfg: cfg, exchange: exchange)
+    },
   )
 }
 
 pub fn authorize_url_returns_authorization_request_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "http://localhost/cb")
-  let assert Ok(req) = vestibule.authorize_url(strat, conf)
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/cb",
+    )
+  let assert Ok(req) = vestibule.authorize_url(strat, cfg: conf)
   let url = authorization_request.url(req)
   let state = authorization_request.state(req)
   let verifier = authorization_request.code_verifier(req)
@@ -163,8 +177,13 @@ pub fn authorize_url_returns_authorization_request_test() {
 }
 
 pub fn authorize_url_appends_pkce_before_url_fragment_test() {
-  let conf = config.new("id", "secret", "http://localhost/cb")
-  let assert Ok(req) = vestibule.authorize_url(fragment_strategy(), conf)
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/cb",
+    )
+  let assert Ok(req) = vestibule.authorize_url(fragment_strategy(), cfg: conf)
   let url = authorization_request.url(req)
 
   { string.contains(url, "&existing=1&code_challenge=") }
@@ -176,9 +195,13 @@ pub fn authorize_url_appends_pkce_before_url_fragment_test() {
 pub fn authorize_url_uses_config_scopes_when_present_test() {
   let strat = test_strategy()
   let conf =
-    config.new("id", "secret", "http://localhost/cb")
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/cb",
+    )
     |> config.with_scopes(["custom_scope"])
-  let assert Ok(req) = vestibule.authorize_url(strat, conf)
+  let assert Ok(req) = vestibule.authorize_url(strat, cfg: conf)
   let url = authorization_request.url(req)
   { string.contains(url, "custom_scope") } |> expect.to_be_true()
   { string.contains(url, "default_scope") } |> expect.to_be_false()
@@ -186,19 +209,35 @@ pub fn authorize_url_uses_config_scopes_when_present_test() {
 
 pub fn authorize_url_uses_default_scopes_when_config_empty_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "http://localhost/cb")
-  let assert Ok(req) = vestibule.authorize_url(strat, conf)
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/cb",
+    )
+  let assert Ok(req) = vestibule.authorize_url(strat, cfg: conf)
   let url = authorization_request.url(req)
   { string.contains(url, "default_scope") } |> expect.to_be_true()
 }
 
 pub fn handle_callback_succeeds_with_valid_params_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "http://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/cb",
+    )
   let state = "test_state_value"
   let params = dict.from_list([#("code", "valid_code"), #("state", state)])
   let result =
-    vestibule.handle_callback(strat, conf, params, state, "test_verifier")
+    vestibule.handle_callback(
+      strat,
+      cfg: conf,
+      callback_params: params,
+      expected_state: state,
+      code_verifier: "test_verifier",
+    )
   let assert Ok(auth) = result
   auth.uid |> expect.to_equal("user123")
   auth.provider |> expect.to_equal("test")
@@ -208,29 +247,45 @@ pub fn handle_callback_succeeds_with_valid_params_test() {
 
 pub fn handle_callback_populates_auth_extra_from_strategy_user_result_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "http://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/cb",
+    )
   let state = "test_state_value"
   let params = dict.from_list([#("code", "valid_code"), #("state", state)])
 
   let assert Ok(auth) =
-    vestibule.handle_callback(strat, conf, params, state, "test_verifier")
+    vestibule.handle_callback(
+      strat,
+      cfg: conf,
+      callback_params: params,
+      expected_state: state,
+      code_verifier: "test_verifier",
+    )
   let assert Ok(raw_provider) = dict.get(auth.extra, "raw_provider")
   decode.run(raw_provider, decode.string)
   |> expect.to_equal(Ok("from-provider"))
 }
 
 pub fn handle_callback_passes_exchange_artifacts_to_fetch_user_test() {
-  let conf = config.new("id", "secret", "http://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/cb",
+    )
   let state = "test_state_value"
   let params = dict.from_list([#("code", "valid_code"), #("state", state)])
 
   let assert Ok(auth) =
     vestibule.handle_callback(
       artifact_strategy(),
-      conf,
-      params,
-      state,
-      "test_verifier",
+      cfg: conf,
+      callback_params: params,
+      expected_state: state,
+      code_verifier: "test_verifier",
     )
 
   auth.uid |> expect.to_equal("from-exchange")
@@ -239,9 +294,14 @@ pub fn handle_callback_passes_exchange_artifacts_to_fetch_user_test() {
 
 pub fn refresh_token_delegates_to_strategy_refresh_token_test() {
   let strat = test_strategy()
-  let conf = config.new("client-id", "secret", "http://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "client-id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/cb",
+    )
 
-  vestibule.refresh_token(strat, conf, "refresh-123")
+  vestibule.refresh_token(strat, cfg: conf, refresh_tok: "refresh-123")
   |> expect.to_equal(
     Ok(
       credentials.new(
@@ -257,40 +317,84 @@ pub fn refresh_token_delegates_to_strategy_refresh_token_test() {
 
 pub fn handle_callback_fails_on_state_mismatch_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "http://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/cb",
+    )
   let params = dict.from_list([#("code", "valid_code"), #("state", "wrong")])
   let result =
-    vestibule.handle_callback(strat, conf, params, "expected", "test_verifier")
+    vestibule.handle_callback(
+      strat,
+      cfg: conf,
+      callback_params: params,
+      expected_state: "expected",
+      code_verifier: "test_verifier",
+    )
   let _ = result |> expect.to_be_error()
   Nil
 }
 
 pub fn missing_callback_state_is_structured_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "http://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/cb",
+    )
   let params = dict.from_list([#("code", "valid_code")])
 
-  vestibule.handle_callback(strat, conf, params, "expected", "test_verifier")
+  vestibule.handle_callback(
+    strat,
+    cfg: conf,
+    callback_params: params,
+    expected_state: "expected",
+    code_verifier: "test_verifier",
+  )
   |> expect.to_equal(Error(error.MissingCallbackParam("state")))
 }
 
 pub fn handle_callback_fails_on_missing_code_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "http://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/cb",
+    )
   let state = "test_state"
   let params = dict.from_list([#("state", state)])
   let result =
-    vestibule.handle_callback(strat, conf, params, state, "test_verifier")
+    vestibule.handle_callback(
+      strat,
+      cfg: conf,
+      callback_params: params,
+      expected_state: state,
+      code_verifier: "test_verifier",
+    )
   let _ = result |> expect.to_be_error()
   Nil
 }
 
 pub fn missing_callback_code_is_structured_test() {
   let strat = test_strategy()
-  let conf = config.new("id", "secret", "http://localhost/cb")
+  let conf =
+    config.new(
+      client_id: "id",
+      client_secret: "secret",
+      redirect_uri: "http://localhost/cb",
+    )
   let state = "test_state"
   let params = dict.from_list([#("state", state)])
 
-  vestibule.handle_callback(strat, conf, params, state, "test_verifier")
+  vestibule.handle_callback(
+    strat,
+    cfg: conf,
+    callback_params: params,
+    expected_state: state,
+    code_verifier: "test_verifier",
+  )
   |> expect.to_equal(Error(error.MissingCallbackParam("code")))
 }


### PR DESCRIPTION
## Summary

Adds [glinter](https://hex.pm/packages/glinter) linting across the monorepo, wires it into `just` and CI, and resolves every resulting warning so lint runs clean in **strict mode**.

## Tooling
- Add `glinter` dev-dependency and per-package `[tools.glinter]` config
- Add `just lint` / `just lint-pkg` recipes; add `lint` to `just ci`
- Add a **Lint** job to the CI workflow
- Enable `warnings_as_errors = true` — any lint warning now fails the build

> [!NOTE]
> glinter does **not** implement per-rule error severity (`rule = "error"` is parsed but never applied). The only working strictness lever is the global `warnings_as_errors`, which promotes every enabled rule's warnings to errors.

## Warning cleanup
- **Mechanical fixes:** string-literal concatenations, a missing type annotation, short variable names (`r`→`req`), guard clauses (`case` → `bool.guard`), discarded results, one deeply-nested block
- **Design-intentional rules suppressed** with explanatory comments: `unused_exports`, `assert_ok_pattern`, `error_context_lost`, `thrown_away_error`, `stringly_typed_error`
- **Argument labels** added to Tier 1 & 2 public functions and **relabeled call sites** across `src`, `example`, and tests (non-breaking — positional/`use` calls still compile)
- `label_possible = "off"` (remaining unlabelled args are intentional subject/pipe receivers), while `missing_labels` stays enforced so labelled functions must be called with labels

## Verification
- `just lint` — clean across all 8 packages (exit 0)
- `just check` — passes
- `just test` — all 284 tests pass
- `just format` — clean

