### PR TITLE
docs(W-mqi92olb0004e3ae): align README 1.0 language with pre-1.0 version (#92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ The name "vestibule" refers to an entrance hall — the transitional space betwe
 [![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/vestibule/)
 
 > [!NOTE]
-> vestibule follows [Semantic Versioning](https://semver.org/) for 1.0 and
-> later releases. Public APIs are intended to be stable across patch and minor
-> releases; breaking changes are reserved for major versions.
+> vestibule is pre-1.0 (currently `0.x`). The public API is still subject to
+> change and breaking changes may land before 1.0. Once 1.0 ships, vestibule
+> will follow [Semantic Versioning](https://semver.org/): public APIs stable
+> across patch and minor releases, with breaking changes reserved for major
+> versions.
 >
 > OAuth security depends on application configuration too: production redirect
 > URIs must use HTTPS. `http://localhost` and `http://127.0.0.1` redirect URIs
@@ -274,7 +276,8 @@ common attacks, but a few responsibilities remain with the consuming app.
 
 ## API Notes
 
-The root package has two intended public surfaces for 1.0.
+The root package has two intended public surfaces for the planned 1.0 API.
+Before 1.0, this API is still subject to change.
 
 **Application API** modules are for apps that run OAuth flows directly or through
 the middleware packages:


### PR DESCRIPTION
## Summary

Resolves #92. The README described the API as the shipped 1.0 API and stated SemVer guarantees apply "for 1.0 and later releases," but the root package is still `0.1.0` (`gleam.toml:2`) with no changelog release entries. This adopts **option 1** from the issue (pre-release hardening): soften the wording so the docs no longer imply 1.0 is shipped.

## Changes (README.md only)

- **Versioning note (lines ~10-13):** reworded to state vestibule is pre-1.0 (`0.x`) and the public API is still subject to change, with breaking changes possible before 1.0. The SemVer guarantee is now framed as taking effect "once 1.0 ships."
- **API Notes (line ~277):** changed "two intended public surfaces for 1.0" to "for the planned 1.0 API" and added "Before 1.0, this API is still subject to change." Technical meaning preserved.

## Not changed

- `gleam.toml` version — left at `0.1.0` (no bump, per issue).
- `CHANGELOG.md` — no fabricated release entries. The header only states SemVer adherence, which is valid for `0.x` too, so it stays consistent with the pre-1.0 framing.
- No code or behavior changes.

## Validation

Docs-only wording change; no build/test impact.
