### PR TITLE
feat: rename authorize_url -> create_authorization_request (#90)

### DIFF
--- a/.changes/unreleased/vestibule-Breaking-20260617-085800.yaml
+++ b/.changes/unreleased/vestibule-Breaking-20260617-085800.yaml
@@ -1,0 +1,4 @@
+project: vestibule
+kind: Breaking
+body: Renamed `vestibule.authorize_url` to `vestibule.create_authorization_request`. The function generates CSRF state and a PKCE verifier in addition to building the URL, so the new name reflects that it starts an authorization request whose state and verifier must be persisted. The old name has been removed (no deprecated alias).
+time: 2026-06-17T08:58:00.000000-07:00

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ let cfg =
   )
 
 // Phase 1: Generate authorization URL and redirect user
-let assert Ok(auth_request) = vestibule.authorize_url(strategy, cfg)
+let assert Ok(auth_request) = vestibule.create_authorization_request(strategy, cfg)
 // Store auth_request.state and auth_request.code_verifier server-side,
 // bound to this user's session, with an expiration time.
 // Redirect user to auth_request.url

--- a/docs/guides/writing-a-custom-strategy.md
+++ b/docs/guides/writing-a-custom-strategy.md
@@ -27,7 +27,7 @@ Each strategy tells vestibule how to talk to a specific OAuth2 provider: how to 
 
 Vestibule authenticates users in two phases:
 
-1. **Request phase** -- Your application calls `vestibule.authorize_url(strategy, config)`. Vestibule generates a CSRF state token and PKCE code verifier, calls your strategy's `authorize_url` function to build the provider-specific URL, then appends the PKCE `code_challenge` parameter. You get back an `AuthorizationRequest` containing the URL, state, and code verifier. Store the state and code verifier in the user's session, then redirect them to the URL.
+1. **Request phase** -- Your application calls `vestibule.create_authorization_request(strategy, config)`. Vestibule generates a CSRF state token and PKCE code verifier, calls your strategy's `authorize_url` function to build the provider-specific URL, then appends the PKCE `code_challenge` parameter. You get back an `AuthorizationRequest` containing the URL, state, and code verifier. Store the state and code verifier in the user's session, then redirect them to the URL.
 
 2. **Callback phase** -- The provider redirects the user back to your application with a `code` and `state` parameter. Your application calls `vestibule.handle_callback(strategy, config, params, expected_state, code_verifier)`. Vestibule validates the CSRF state, calls your strategy's `exchange_code` function (passing the PKCE code verifier), then calls your strategy's `fetch_user` function with the config and `ExchangeResult`. You get back an `Auth` record with the user's UID, normalized info, provider extras, and OAuth credentials.
 
@@ -525,7 +525,7 @@ pub fn start_auth() {
       "http://localhost:8080/auth/twitch/callback",
     )
   let strategy = vestibule_twitch.strategy()
-  let assert Ok(auth_request) = vestibule.authorize_url(strategy, twitch_config)
+  let assert Ok(auth_request) = vestibule.create_authorization_request(strategy, twitch_config)
   // Store auth_request.state and auth_request.code_verifier in session
   // Redirect user to auth_request.url
 }

--- a/src/vestibule.gleam
+++ b/src/vestibule.gleam
@@ -32,7 +32,7 @@ import vestibule/strategy.{type Strategy}
 /// not enforce expiration. If you need time-based expiration, store a
 /// timestamp alongside the state when saving it to your session and
 /// check it before calling `handle_callback`.
-pub fn authorize_url(
+pub fn create_authorization_request(
   strat: Strategy(e),
   cfg cfg: Config,
 ) -> Result(AuthorizationRequest, AuthError(e)) {

--- a/src/vestibule/transport_flow.gleam
+++ b/src/vestibule/transport_flow.gleam
@@ -39,7 +39,7 @@ pub fn start_authorization(
     |> result.map_error(fn(_) { UnknownProvider(provider) }),
   )
   use auth_request <- result.try(
-    vestibule.authorize_url(strategy, cfg: config)
+    vestibule.create_authorization_request(strategy, cfg: config)
     |> result.map_error(AuthFailed),
   )
   use session_id <- result.try(

--- a/test/vestibule/security_test.gleam
+++ b/test/vestibule/security_test.gleam
@@ -186,7 +186,7 @@ pub fn pkce_different_verifiers_produce_different_challenges_test() {
 
 /// Security: authorization URL must always include PKCE params.
 /// No code path should produce a URL without code_challenge.
-pub fn authorize_url_always_includes_pkce_test() {
+pub fn create_authorization_request_always_includes_pkce_test() {
   let strat = test_strategy()
   let conf =
     config.new(
@@ -194,14 +194,15 @@ pub fn authorize_url_always_includes_pkce_test() {
       client_secret: "secret",
       redirect_uri: "https://localhost/cb",
     )
-  let assert Ok(auth_req) = vestibule.authorize_url(strat, cfg: conf)
+  let assert Ok(auth_req) =
+    vestibule.create_authorization_request(strat, cfg: conf)
   let url = authorization_request.url(auth_req)
   { string.contains(url, "code_challenge=") } |> expect.to_be_true()
   { string.contains(url, "code_challenge_method=S256") } |> expect.to_be_true()
 }
 
-/// Security: authorize_url state and verifier must differ on each call.
-pub fn authorize_url_produces_fresh_state_and_verifier_test() {
+/// Security: create_authorization_request state and verifier must differ on each call.
+pub fn create_authorization_request_produces_fresh_state_and_verifier_test() {
   let strat = test_strategy()
   let conf =
     config.new(
@@ -209,8 +210,8 @@ pub fn authorize_url_produces_fresh_state_and_verifier_test() {
       client_secret: "secret",
       redirect_uri: "https://localhost/cb",
     )
-  let assert Ok(req1) = vestibule.authorize_url(strat, cfg: conf)
-  let assert Ok(req2) = vestibule.authorize_url(strat, cfg: conf)
+  let assert Ok(req1) = vestibule.create_authorization_request(strat, cfg: conf)
+  let assert Ok(req2) = vestibule.create_authorization_request(strat, cfg: conf)
   { authorization_request.state(req1) != authorization_request.state(req2) }
   |> expect.to_be_true()
   {

--- a/test/vestibule_test.gleam
+++ b/test/vestibule_test.gleam
@@ -153,7 +153,7 @@ fn fragment_strategy() -> Strategy(e) {
   )
 }
 
-pub fn authorize_url_returns_authorization_request_test() {
+pub fn create_authorization_request_returns_authorization_request_test() {
   let strat = test_strategy()
   let conf =
     config.new(
@@ -161,7 +161,7 @@ pub fn authorize_url_returns_authorization_request_test() {
       client_secret: "secret",
       redirect_uri: "http://localhost/cb",
     )
-  let assert Ok(req) = vestibule.authorize_url(strat, cfg: conf)
+  let assert Ok(req) = vestibule.create_authorization_request(strat, cfg: conf)
   let url = authorization_request.url(req)
   let state = authorization_request.state(req)
   let verifier = authorization_request.code_verifier(req)
@@ -176,14 +176,15 @@ pub fn authorize_url_returns_authorization_request_test() {
   { string.contains(url, "code_challenge_method=S256") } |> expect.to_be_true()
 }
 
-pub fn authorize_url_appends_pkce_before_url_fragment_test() {
+pub fn create_authorization_request_appends_pkce_before_url_fragment_test() {
   let conf =
     config.new(
       client_id: "id",
       client_secret: "secret",
       redirect_uri: "http://localhost/cb",
     )
-  let assert Ok(req) = vestibule.authorize_url(fragment_strategy(), cfg: conf)
+  let assert Ok(req) =
+    vestibule.create_authorization_request(fragment_strategy(), cfg: conf)
   let url = authorization_request.url(req)
 
   { string.contains(url, "&existing=1&code_challenge=") }
@@ -192,7 +193,7 @@ pub fn authorize_url_appends_pkce_before_url_fragment_test() {
   |> expect.to_be_true()
 }
 
-pub fn authorize_url_uses_config_scopes_when_present_test() {
+pub fn create_authorization_request_uses_config_scopes_when_present_test() {
   let strat = test_strategy()
   let conf =
     config.new(
@@ -201,13 +202,13 @@ pub fn authorize_url_uses_config_scopes_when_present_test() {
       redirect_uri: "http://localhost/cb",
     )
     |> config.with_scopes(["custom_scope"])
-  let assert Ok(req) = vestibule.authorize_url(strat, cfg: conf)
+  let assert Ok(req) = vestibule.create_authorization_request(strat, cfg: conf)
   let url = authorization_request.url(req)
   { string.contains(url, "custom_scope") } |> expect.to_be_true()
   { string.contains(url, "default_scope") } |> expect.to_be_false()
 }
 
-pub fn authorize_url_uses_default_scopes_when_config_empty_test() {
+pub fn create_authorization_request_uses_default_scopes_when_config_empty_test() {
   let strat = test_strategy()
   let conf =
     config.new(
@@ -215,7 +216,7 @@ pub fn authorize_url_uses_default_scopes_when_config_empty_test() {
       client_secret: "secret",
       redirect_uri: "http://localhost/cb",
     )
-  let assert Ok(req) = vestibule.authorize_url(strat, cfg: conf)
+  let assert Ok(req) = vestibule.create_authorization_request(strat, cfg: conf)
   let url = authorization_request.url(req)
   { string.contains(url, "default_scope") } |> expect.to_be_true()
 }

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -39,7 +39,7 @@ let cfg =
     "http://localhost:8000/auth/github/callback",
   )
 
-let assert Ok(auth_request) = vestibule.authorize_url(strategy, cfg)
+let assert Ok(auth_request) = vestibule.create_authorization_request(strategy, cfg)
 // Store auth_request.state and auth_request.code_verifier server-side,
 // bound to this user's session, with an expiration time.
 // Redirect user to auth_request.url.

--- a/website/src/content/packages/core.md
+++ b/website/src/content/packages/core.md
@@ -31,7 +31,7 @@ code: |
       "http://localhost:8000/auth/github/callback",
     )
 
-  let assert Ok(auth_request) = vestibule.authorize_url(strategy, cfg)
+  let assert Ok(auth_request) = vestibule.create_authorization_request(strategy, cfg)
   // Store auth_request.state and auth_request.code_verifier server-side.
   // Redirect the user to auth_request.url.
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -44,7 +44,7 @@ const supportedProviders = [
     icon: siApple
   }
 ];
-const directFlow = `let assert Ok(auth_request) = vestibule.authorize_url(strategy, cfg)
+const directFlow = `let assert Ok(auth_request) = vestibule.create_authorization_request(strategy, cfg)
 // Store auth_request.state and auth_request.code_verifier.
 // Redirect to auth_request.url.
 


### PR DESCRIPTION
## Summary

Resolves #90. Renames the public `vestibule.authorize_url` function to `vestibule.create_authorization_request`.

The old name undersold the function's behavior. It does far more than build a URL: it generates a CSRF state token, generates a PKCE code verifier, computes the code challenge, calls the provider strategy, appends the PKCE parameters, and returns an `AuthorizationRequest`. The new name reflects that it **starts an authorization request** whose `state` and `code_verifier` must be persisted by the caller.

This is a pre-1.0 package (`gleam.toml` version `0.1.0`) with no compatibility promise, so the old name is **removed** rather than kept as a deprecated alias.

## Changes

- `src/vestibule.gleam` — renamed `pub fn authorize_url` → `pub fn create_authorization_request` (signature and `AuthorizationRequest` return type unchanged).
- `src/vestibule/transport_flow.gleam` — updated the internal call site in `start_authorization`.
- Tests (`test/vestibule_test.gleam`, `test/vestibule/security_test.gleam`) — updated all call sites and renamed the affected test functions.
- Docs — `README.md` quick start, `docs/guides/writing-a-custom-strategy.md`, and the `website/` Starlight docs (`quick-start.mdx`, `packages/core.md`, `index.astro`).
- Added a `Breaking` changie fragment for the `vestibule` core package.

### Explicitly NOT changed
- The `Strategy` record field `authorize_url` and `strategy.build_authorize_url` — these are the provider-strategy URL builders, a separate concept.
- Provider helper functions named `do_authorize_url`.
- Dated historical design/implementation plans under `docs/plans/` and `docs/superpowers/plans/` — left as point-in-time archival records (some also show an outdated return type).

## Validation

Commands run from the worktree:

- `gleam format src test` — clean
- `gleam build --warnings-as-errors` (core) — compiled
- `gleam test` (core) — **186 passed**
- `cd packages/vestibule_wisp && gleam build` — compiled
- `cd packages/vestibule_mist && gleam build` — compiled

No package or example source calls the public function directly (verified via grep), so no cross-repo/package code changes were required.
