### PR TITLE
feat!: rename authorize_url to create_authorization_request

### DIFF
--- a/.changes/unreleased/vestibule-Changed-20260617-090200.yaml
+++ b/.changes/unreleased/vestibule-Changed-20260617-090200.yaml
@@ -1,0 +1,4 @@
+project: vestibule
+kind: Changed
+body: 'Renamed the public `vestibule.authorize_url` function to `vestibule.create_authorization_request` to reflect that it generates CSRF state and PKCE parameters and returns a full `AuthorizationRequest`, not just a URL. This is a breaking rename with no compatibility alias (pre-1.0); update call sites accordingly.'
+time: 2026-06-17T09:02:00.000000000-07:00

--- a/.changes/unreleased/vestibule-Changed-20260617-090200.yaml
+++ b/.changes/unreleased/vestibule-Changed-20260617-090200.yaml
@@ -1,4 +1,0 @@
-project: vestibule
-kind: Changed
-body: 'Renamed the public `vestibule.authorize_url` function to `vestibule.create_authorization_request` to reflect that it generates CSRF state and PKCE parameters and returns a full `AuthorizationRequest`, not just a URL. This is a breaking rename with no compatibility alias (pre-1.0); update call sites accordingly.'
-time: 2026-06-17T09:02:00.000000000-07:00

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ let cfg =
   )
 
 // Phase 1: Generate authorization URL and redirect user
-let assert Ok(auth_request) = vestibule.authorize_url(strategy, cfg)
+let assert Ok(auth_request) = vestibule.create_authorization_request(strategy, cfg)
 // Store auth_request.state and auth_request.code_verifier server-side,
 // bound to this user's session, with an expiration time.
 // Redirect user to auth_request.url

--- a/docs/guides/writing-a-custom-strategy.md
+++ b/docs/guides/writing-a-custom-strategy.md
@@ -27,7 +27,7 @@ Each strategy tells vestibule how to talk to a specific OAuth2 provider: how to 
 
 Vestibule authenticates users in two phases:
 
-1. **Request phase** -- Your application calls `vestibule.authorize_url(strategy, config)`. Vestibule generates a CSRF state token and PKCE code verifier, calls your strategy's `authorize_url` function to build the provider-specific URL, then appends the PKCE `code_challenge` parameter. You get back an `AuthorizationRequest` containing the URL, state, and code verifier. Store the state and code verifier in the user's session, then redirect them to the URL.
+1. **Request phase** -- Your application calls `vestibule.create_authorization_request(strategy, config)`. Vestibule generates a CSRF state token and PKCE code verifier, calls your strategy's `authorize_url` function to build the provider-specific URL, then appends the PKCE `code_challenge` parameter. You get back an `AuthorizationRequest` containing the URL, state, and code verifier. Store the state and code verifier in the user's session, then redirect them to the URL.
 
 2. **Callback phase** -- The provider redirects the user back to your application with a `code` and `state` parameter. Your application calls `vestibule.handle_callback(strategy, config, params, expected_state, code_verifier)`. Vestibule validates the CSRF state, calls your strategy's `exchange_code` function (passing the PKCE code verifier), then calls your strategy's `fetch_user` function with the config and `ExchangeResult`. You get back an `Auth` record with the user's UID, normalized info, provider extras, and OAuth credentials.
 
@@ -525,7 +525,7 @@ pub fn start_auth() {
       "http://localhost:8080/auth/twitch/callback",
     )
   let strategy = vestibule_twitch.strategy()
-  let assert Ok(auth_request) = vestibule.authorize_url(strategy, twitch_config)
+  let assert Ok(auth_request) = vestibule.create_authorization_request(strategy, twitch_config)
   // Store auth_request.state and auth_request.code_verifier in session
   // Redirect user to auth_request.url
 }

--- a/src/vestibule.gleam
+++ b/src/vestibule.gleam
@@ -32,7 +32,7 @@ import vestibule/strategy.{type Strategy}
 /// not enforce expiration. If you need time-based expiration, store a
 /// timestamp alongside the state when saving it to your session and
 /// check it before calling `handle_callback`.
-pub fn authorize_url(
+pub fn create_authorization_request(
   strat: Strategy(e),
   cfg cfg: Config,
 ) -> Result(AuthorizationRequest, AuthError(e)) {

--- a/src/vestibule/transport_flow.gleam
+++ b/src/vestibule/transport_flow.gleam
@@ -39,7 +39,7 @@ pub fn start_authorization(
     |> result.map_error(fn(_) { UnknownProvider(provider) }),
   )
   use auth_request <- result.try(
-    vestibule.authorize_url(strategy, cfg: config)
+    vestibule.create_authorization_request(strategy, cfg: config)
     |> result.map_error(AuthFailed),
   )
   use session_id <- result.try(

--- a/test/vestibule/security_test.gleam
+++ b/test/vestibule/security_test.gleam
@@ -186,7 +186,7 @@ pub fn pkce_different_verifiers_produce_different_challenges_test() {
 
 /// Security: authorization URL must always include PKCE params.
 /// No code path should produce a URL without code_challenge.
-pub fn authorize_url_always_includes_pkce_test() {
+pub fn create_authorization_request_always_includes_pkce_test() {
   let strat = test_strategy()
   let conf =
     config.new(
@@ -194,14 +194,15 @@ pub fn authorize_url_always_includes_pkce_test() {
       client_secret: "secret",
       redirect_uri: "https://localhost/cb",
     )
-  let assert Ok(auth_req) = vestibule.authorize_url(strat, cfg: conf)
+  let assert Ok(auth_req) =
+    vestibule.create_authorization_request(strat, cfg: conf)
   let url = authorization_request.url(auth_req)
   { string.contains(url, "code_challenge=") } |> expect.to_be_true()
   { string.contains(url, "code_challenge_method=S256") } |> expect.to_be_true()
 }
 
-/// Security: authorize_url state and verifier must differ on each call.
-pub fn authorize_url_produces_fresh_state_and_verifier_test() {
+/// Security: create_authorization_request state and verifier must differ on each call.
+pub fn create_authorization_request_produces_fresh_state_and_verifier_test() {
   let strat = test_strategy()
   let conf =
     config.new(
@@ -209,8 +210,8 @@ pub fn authorize_url_produces_fresh_state_and_verifier_test() {
       client_secret: "secret",
       redirect_uri: "https://localhost/cb",
     )
-  let assert Ok(req1) = vestibule.authorize_url(strat, cfg: conf)
-  let assert Ok(req2) = vestibule.authorize_url(strat, cfg: conf)
+  let assert Ok(req1) = vestibule.create_authorization_request(strat, cfg: conf)
+  let assert Ok(req2) = vestibule.create_authorization_request(strat, cfg: conf)
   { authorization_request.state(req1) != authorization_request.state(req2) }
   |> expect.to_be_true()
   {

--- a/test/vestibule_test.gleam
+++ b/test/vestibule_test.gleam
@@ -153,7 +153,7 @@ fn fragment_strategy() -> Strategy(e) {
   )
 }
 
-pub fn authorize_url_returns_authorization_request_test() {
+pub fn create_authorization_request_returns_authorization_request_test() {
   let strat = test_strategy()
   let conf =
     config.new(
@@ -161,7 +161,7 @@ pub fn authorize_url_returns_authorization_request_test() {
       client_secret: "secret",
       redirect_uri: "http://localhost/cb",
     )
-  let assert Ok(req) = vestibule.authorize_url(strat, cfg: conf)
+  let assert Ok(req) = vestibule.create_authorization_request(strat, cfg: conf)
   let url = authorization_request.url(req)
   let state = authorization_request.state(req)
   let verifier = authorization_request.code_verifier(req)
@@ -176,14 +176,15 @@ pub fn authorize_url_returns_authorization_request_test() {
   { string.contains(url, "code_challenge_method=S256") } |> expect.to_be_true()
 }
 
-pub fn authorize_url_appends_pkce_before_url_fragment_test() {
+pub fn create_authorization_request_appends_pkce_before_url_fragment_test() {
   let conf =
     config.new(
       client_id: "id",
       client_secret: "secret",
       redirect_uri: "http://localhost/cb",
     )
-  let assert Ok(req) = vestibule.authorize_url(fragment_strategy(), cfg: conf)
+  let assert Ok(req) =
+    vestibule.create_authorization_request(fragment_strategy(), cfg: conf)
   let url = authorization_request.url(req)
 
   { string.contains(url, "&existing=1&code_challenge=") }
@@ -192,7 +193,7 @@ pub fn authorize_url_appends_pkce_before_url_fragment_test() {
   |> expect.to_be_true()
 }
 
-pub fn authorize_url_uses_config_scopes_when_present_test() {
+pub fn create_authorization_request_uses_config_scopes_when_present_test() {
   let strat = test_strategy()
   let conf =
     config.new(
@@ -201,13 +202,13 @@ pub fn authorize_url_uses_config_scopes_when_present_test() {
       redirect_uri: "http://localhost/cb",
     )
     |> config.with_scopes(["custom_scope"])
-  let assert Ok(req) = vestibule.authorize_url(strat, cfg: conf)
+  let assert Ok(req) = vestibule.create_authorization_request(strat, cfg: conf)
   let url = authorization_request.url(req)
   { string.contains(url, "custom_scope") } |> expect.to_be_true()
   { string.contains(url, "default_scope") } |> expect.to_be_false()
 }
 
-pub fn authorize_url_uses_default_scopes_when_config_empty_test() {
+pub fn create_authorization_request_uses_default_scopes_when_config_empty_test() {
   let strat = test_strategy()
   let conf =
     config.new(
@@ -215,7 +216,7 @@ pub fn authorize_url_uses_default_scopes_when_config_empty_test() {
       client_secret: "secret",
       redirect_uri: "http://localhost/cb",
     )
-  let assert Ok(req) = vestibule.authorize_url(strat, cfg: conf)
+  let assert Ok(req) = vestibule.create_authorization_request(strat, cfg: conf)
   let url = authorization_request.url(req)
   { string.contains(url, "default_scope") } |> expect.to_be_true()
 }

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -39,7 +39,7 @@ let cfg =
     "http://localhost:8000/auth/github/callback",
   )
 
-let assert Ok(auth_request) = vestibule.authorize_url(strategy, cfg)
+let assert Ok(auth_request) = vestibule.create_authorization_request(strategy, cfg)
 // Store auth_request.state and auth_request.code_verifier server-side,
 // bound to this user's session, with an expiration time.
 // Redirect user to auth_request.url.

--- a/website/src/content/packages/core.md
+++ b/website/src/content/packages/core.md
@@ -31,7 +31,7 @@ code: |
       "http://localhost:8000/auth/github/callback",
     )
 
-  let assert Ok(auth_request) = vestibule.authorize_url(strategy, cfg)
+  let assert Ok(auth_request) = vestibule.create_authorization_request(strategy, cfg)
   // Store auth_request.state and auth_request.code_verifier server-side.
   // Redirect the user to auth_request.url.
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -44,7 +44,7 @@ const supportedProviders = [
     icon: siApple
   }
 ];
-const directFlow = `let assert Ok(auth_request) = vestibule.authorize_url(strategy, cfg)
+const directFlow = `let assert Ok(auth_request) = vestibule.create_authorization_request(strategy, cfg)
 // Store auth_request.state and auth_request.code_verifier.
 // Redirect to auth_request.url.
 


### PR DESCRIPTION
## Summary

Closes #90.

Renames the public `vestibule.authorize_url` function to **`vestibule.create_authorization_request`**. The name better reflects what the function actually does: it generates a CSRF state token, generates a PKCE verifier and computes its challenge, calls the provider strategy, appends PKCE params, and returns a full `AuthorizationRequest` (URL + state + code verifier) — not just a URL.

This is a **clean breaking rename with no deprecated alias**, since the package is pre-1.0 (0.1.0) with no stability promise yet, avoiding carrying dead surface into 1.0.

## Naming choice

Picked `create_authorization_request` (matches the returned `AuthorizationRequest` type) over `start_authorization`, which would also collide with the existing `transport_flow.start_authorization`.

## Scope

Renamed **only** the public `vestibule.authorize_url` orchestrator. Left untouched (correctly named — they really do just build a URL):
- the `strategy.authorize_url` callback field
- `strategy.build_authorize_url`
- each provider's `do_authorize_url` helper

## Changes

- `src/vestibule.gleam` — function definition
- `src/vestibule/transport_flow.gleam` — internal call site
- `test/vestibule_test.gleam`, `test/vestibule/security_test.gleam` — call sites + test function names
- `README.md`, `website/src/pages/index.astro`, `website/src/content/packages/core.md`, `website/src/content/docs/quick-start.mdx`, `docs/guides/writing-a-custom-strategy.md` — doc/example usage
- `.changes/unreleased/vestibule-Changed-20260617-090200.yaml` — changelog fragment

Historical point-in-time records under `docs/plans/` and `docs/prd/` were intentionally left unchanged.

## Validation

- `gleam format src test` — clean; `just format-check` — clean
- `gleam build --warnings-as-errors` — clean
- `just test-all` — all packages green: core 186, apple 23, github 10, google 17, microsoft 18, wisp 12, mist 16
