### PR TITLE
docs(website): harden OAuth examples, add search palette, polish docs

### DIFF
--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -1,0 +1,38 @@
+{
+  "detector": {
+    "ignoreRules": [],
+    "ignoreFiles": [],
+    "ignoreValues": [
+      {
+        "rule": "design-system-color",
+        "value": "#f25022",
+        "reason": "Microsoft brand-square color; legitimate provider identity, not palette drift",
+        "createdAt": "2026-06-19T00:19:09.657Z"
+      },
+      {
+        "rule": "design-system-color",
+        "value": "#7fba00",
+        "reason": "Microsoft brand-square color; legitimate provider identity, not palette drift",
+        "createdAt": "2026-06-19T00:19:09.778Z"
+      },
+      {
+        "rule": "design-system-color",
+        "value": "#00a4ef",
+        "reason": "Microsoft brand-square color; legitimate provider identity, not palette drift",
+        "createdAt": "2026-06-19T00:19:09.885Z"
+      },
+      {
+        "rule": "design-system-color",
+        "value": "#ffb900",
+        "reason": "Microsoft brand-square color; legitimate provider identity, not palette drift",
+        "createdAt": "2026-06-19T00:19:09.992Z"
+      },
+      {
+        "rule": "design-system-color",
+        "value": "oklch(0 0 0 / 0.5)",
+        "reason": "Modal overlay shadow; documented in DESIGN.md Elevation as intentional top-layer depth",
+        "createdAt": "2026-06-19T00:19:10.107Z"
+      }
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -61,8 +61,11 @@ components:
     backgroundColor: "{colors.brand-purple-hover}"
     textColor: "{colors.background}"
   button-secondary:
-    backgroundColor: "{colors.threshold-yellow}"
+    backgroundColor: "{colors.surface}"
     textColor: "{colors.ink}"
+    border: "1px solid {colors.border}"
+    borderColorHover: "{colors.brand-purple}"
+    backgroundColorHover: "{colors.brand-purple-soft}"
     typography: "{typography.label}"
     rounded: "{rounded.sm}"
     padding: "12px 18px"
@@ -106,7 +109,7 @@ The palette is restrained product purple with yellow used as a deliberate signal
 - **Soft Vestibule Purple** (`brand-purple-soft`): A pale purple support surface for provider chips, selected rows, and informational callouts that need brand continuity without visual weight.
 
 ### Secondary
-- **Threshold Yellow** (`threshold-yellow`): The logo-derived signal accent. Use sparingly for secondary CTAs, warning-adjacent guidance, focus halos, and "next step" highlights. Pair with `ink`, not white, so the accent stays readable.
+- **Threshold Yellow** (`threshold-yellow`): The logo-derived signal accent. Use sparingly for focus halos, step numbers, warning-adjacent guidance, and "next step" highlights — never as a button or surface fill (see the Checkpoint Light Rule). Pair with `ink`, not white, so the accent stays readable.
 
 ### Neutral
 - **White Background** (`background`): The default canvas. Do not warm-tint the whole page; the warmth comes from yellow, not the body background.
@@ -154,6 +157,7 @@ Vestibule should be flat by default. Depth comes from tonal layering, soft borde
 
 ### Shadow Vocabulary
 - **Interactive Lift** (`0 6px 12px oklch(0.200 0.035 300 / 0.10)`): Optional hover lift for a primary CTA or provider button on a marketing-adjacent demo surface. Do not combine it with a decorative 1px border unless the border is structural and the blur stays small.
+- **Modal Overlay** (light `0 24px 64px oklch(0.200 0.035 300 / 0.28)`, dark `0 24px 64px oklch(0 0 0 / 0.5)`): Reserved for top-layer surfaces that float above a dimmed backdrop — the command palette and any future `<dialog>`. This is the one place a broad shadow is intentional, because the element is detached from the page and needs to read as lifted; it stays off resting surfaces.
 
 ### Named Rules
 
@@ -165,7 +169,7 @@ Vestibule should be flat by default. Depth comes from tonal layering, soft borde
 - **Shape:** Crisp, modest rounding (6px). No pill buttons unless the control is a compact chip.
 - **Primary:** Filled `brand-purple` with white text, label typography, and 12px 18px padding.
 - **Hover / Focus:** Hover shifts to `brand-purple-hover`; focus uses a 3px `threshold-yellow` outline offset by 2px.
-- **Secondary / Ghost:** Yellow secondary buttons use `threshold-yellow` with `ink` text. Ghost buttons are text-first with a transparent background and purple hover surface.
+- **Secondary / Ghost:** Secondary buttons are a neutral outline — `surface` background, `ink` text, 1px `border` — that shifts to a `brand-purple` border over a `brand-purple-soft` surface on hover. Ghost buttons are text-first with a transparent background and purple hover surface. Yellow is never a button fill; it stays a signal accent.
 - **Touch:** Interactive buttons and compact links must keep a 44px minimum hit area on coarse-pointer devices, even when their visual style stays compact.
 
 ### Chips

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -10,13 +10,18 @@ const navSchema = z.object({
   hidden: z.boolean().default(false)
 });
 
+const tocEntrySchema = z.object({
+  href: z.string(),
+  label: z.string()
+});
+
 const docs = defineCollection({
   loader: glob({ base: "./src/content/docs", pattern: "**/*.{md,mdx}" }),
   schema: z.object({
     title: z.string(),
     description: z.string(),
     nav: navSchema,
-    toc: z.boolean().default(true),
+    toc: z.union([z.boolean(), z.array(tocEntrySchema)]).default(true),
     searchTerms: z.array(z.string()).default([])
   })
 });

--- a/website/src/content/docs/guides/custom-strategy.mdx
+++ b/website/src/content/docs/guides/custom-strategy.mdx
@@ -6,7 +6,15 @@ nav:
   groupOrder: 20
   order: 10
   label: Custom strategy guide
-toc: true
+toc:
+  - href: "#core-boundary"
+    label: What the core handles
+  - href: "#strategy-type"
+    label: The Strategy type
+  - href: "#authoring-steps"
+    label: Authoring steps
+  - href: "#authoring-checklist"
+    label: Authoring checklist
 searchTerms:
   - strategy type
   - custom provider

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -6,7 +6,13 @@ nav:
   groupOrder: 0
   order: 10
   label: Quick start
-toc: true
+toc:
+  - href: "#middleware-path"
+    label: Set up the routes
+  - href: "#callback-failure"
+    label: When the callback fails
+  - href: "#security-responsibilities"
+    label: Before shipping
 searchTerms:
   - middleware
   - wisp
@@ -29,6 +35,7 @@ gleam add vestibule_github`;
 export const coreCode = `import gleam/dict
 import vestibule
 import vestibule/config
+import vestibule/error
 import vestibule_github
 
 let strategy = vestibule_github.strategy()
@@ -50,7 +57,9 @@ let params =
     #("code", "authorization code from callback"),
   ])
 
-let assert Ok(auth) =
+// Validate the callback. Never assert here: state can mismatch and
+// providers can reject the user.
+case
   vestibule.handle_callback(
     strategy,
     cfg,
@@ -58,7 +67,17 @@ let assert Ok(auth) =
     "expected state from session",
     "code verifier from session",
   )
-// Delete the stored state and code_verifier after success.`;
+{
+  Ok(auth) -> {
+    // Delete the stored state and code_verifier, then map auth.uid
+    // to an account and start a session.
+    sign_in(auth)
+  }
+  // Possible CSRF or a stale tab: discard and restart the flow.
+  Error(error.StateMismatch) -> restart_sign_in()
+  // Provider, code-exchange, network, or decode failure.
+  Error(reason) -> show_auth_error(reason)
+}`;
 
 export const wispCode = `import gleam/http
 import wisp
@@ -87,12 +106,42 @@ case wisp.path_segments(req), req.method {
 
   ["auth", provider, "callback"], http.Get
   | ["auth", provider, "callback"], http.Post ->
-    vestibule_wisp.callback_phase(req, reg, provider, store, fn(auth) {
-      wisp.redirect("/dashboard")
-    })
+    case vestibule_wisp.callback_phase_auth_result(req, reg, provider, store) {
+      // auth.uid identifies the user: map it to an account, then
+      // start your own session.
+      Ok(auth) -> start_session(auth)
+
+      // Benign: a stale tab, back button, or already-used callback.
+      Error(vestibule_wisp.SessionExpired) ->
+        wisp.redirect("/login?error=expired")
+
+      // Everything else (forged state, provider rejection, bad params).
+      Error(_) ->
+        wisp.redirect("/login?error=auth")
+    }
 
   _, _ ->
     wisp.not_found()
+}`;
+
+export const callbackFailureCode = `import vestibule
+import vestibule/error
+
+case vestibule.handle_callback(strategy, cfg, params, expected_state, verifier) {
+  Ok(auth) -> sign_in(auth)
+
+  // Wrong state: treat as hostile. Log server-side, restart the flow.
+  Error(error.StateMismatch) -> restart_sign_in()
+
+  // The user denied consent at the provider.
+  Error(error.ProviderError(code: "access_denied", ..)) -> back_to_login()
+
+  // Transient upstream failures are worth a retry prompt.
+  Error(error.NetworkError(_)) | Error(error.CodeExchangeFailed(_)) ->
+    offer_retry()
+
+  // Catch-all: show a generic message, keep the detail in your logs.
+  Error(reason) -> show_auth_error(reason)
 }`;
 
 <section id="middleware-path" className="quick-paths" aria-label="Recommended quick start path">
@@ -147,6 +196,45 @@ case wisp.path_segments(req), req.method {
       <CodeBlock code={coreCode} lang="gleam" />
     </div>
   </details>
+</section>
+
+<section id="callback-failure">
+  <h2>When the callback fails</h2>
+  <p>
+    Most callback failures are benign — a stale tab, the back button, or a
+    re-used link. Some are hostile, like a forged <code>state</code>. Vestibule
+    returns a typed error for both so you can respond safely instead of crashing
+    the request.
+  </p>
+
+  <CodeBlock code={callbackFailureCode} lang="gleam" />
+
+  <div className="content-grid">
+    <div>
+      <h3>Why a callback fails</h3>
+      <ul className="check-list">
+        <li><strong>StateMismatch</strong> — wrong or missing state; possible CSRF.</li>
+        <li><strong>ProviderError</strong> — the provider rejected the request (e.g. denied consent).</li>
+        <li><strong>MissingCallbackParam</strong> — the provider omitted a required value.</li>
+        <li><strong>NetworkError / CodeExchangeFailed</strong> — a transient upstream problem.</li>
+      </ul>
+    </div>
+    <div>
+      <h3>How to respond</h3>
+      <ul className="check-list warning">
+        <li>Discard the stored state and verifier on every failure, then restart the flow.</li>
+        <li>Show users a generic "sign-in failed, try again" message.</li>
+        <li>Keep the specific error in your server logs, never in the response.</li>
+        <li>Offer a retry for transient errors; do not retry a state mismatch.</li>
+      </ul>
+    </div>
+  </div>
+
+  <p className="scope-note">
+    <strong>Do not leak the error.</strong> The <code>reason</code> can name
+    internal details; log it server-side and return a generic message to the
+    browser.
+  </p>
 </section>
 
 <section id="security-responsibilities" className="security-callout">

--- a/website/src/content/packages/core.md
+++ b/website/src/content/packages/core.md
@@ -21,6 +21,7 @@ code: |
   import gleam/dict
   import vestibule
   import vestibule/config
+  import vestibule/error
   import vestibule_github
 
   let strategy = vestibule_github.strategy()
@@ -41,7 +42,9 @@ code: |
       #("code", "authorization code from callback"),
     ])
 
-  let assert Ok(auth) =
+  // Validate the callback. State can mismatch and providers can reject
+  // the user, so handle the error instead of asserting.
+  case
     vestibule.handle_callback(
       strategy,
       cfg,
@@ -49,6 +52,11 @@ code: |
       "expected state from session",
       "code verifier from session",
     )
+  {
+    Ok(auth) -> sign_in(auth)
+    Error(error.StateMismatch) -> restart_sign_in()
+    Error(reason) -> show_auth_error(reason)
+  }
 notes:
   - Production redirect URIs and OIDC issuers must use HTTPS.
   - Redact Auth and Credentials values in logs; bearer tokens are secrets.

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -1,5 +1,5 @@
 ---
-import { getNavigation } from "../data/content";
+import { getNavigation, getSearchEntries } from "../data/content";
 import "../styles/global.css";
 
 type Props = {
@@ -14,6 +14,7 @@ type Props = {
 
 const { title, description, section = "Docs", toc = [] } = Astro.props;
 const navGroups = await getNavigation();
+const searchEntries = await getSearchEntries();
 const pageTitle = title === "Vestibule" ? "Vestibule" : `${title} - Vestibule`;
 const currentPath = Astro.url.pathname.replace(/\/$/, "") || "/";
 
@@ -86,12 +87,12 @@ const hasToc = toc.length > 0;
         <details class="header-resources">
           <summary>Links</summary>
           <nav aria-label="Site links">
-            <a href="/docs/search">Search</a>
+            <a href="/docs/search" data-search-trigger>Search</a>
             <a href="https://hex.pm/packages/vestibule">Hex</a>
             <a href="https://github.com/tylerbutler/vestibule">GitHub</a>
           </nav>
         </details>
-        <a class="header-link" href="/docs/search">Search</a>
+        <a class="header-link" href="/docs/search" data-search-trigger data-search-hint>Search</a>
         <a class="header-link" href="https://hex.pm/packages/vestibule">Hex</a>
         <a class="header-link" href="https://github.com/tylerbutler/vestibule">GitHub</a>
         <button
@@ -174,6 +175,69 @@ const hasToc = toc.length > 0;
         <slot />
       </main>
     </div>
+
+    <dialog class="cmd-palette" data-cmd-palette aria-label="Search documentation">
+      <div class="cmd-palette-inner">
+        <div class="cmd-search-row">
+          <svg class="cmd-search-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              d="M21 21l-4.3-4.3M11 19a8 8 0 100-16 8 8 0 000 16z"
+            ></path>
+          </svg>
+          <input
+            type="search"
+            class="cmd-input"
+            role="combobox"
+            aria-expanded="true"
+            aria-controls="cmd-results"
+            aria-label="Search documentation"
+            aria-autocomplete="list"
+            autocomplete="off"
+            spellcheck="false"
+            placeholder="Try state, PKCE, callback errors, hosted domains"
+            data-cmd-input
+          />
+          <kbd class="cmd-esc-hint" aria-hidden="true">esc</kbd>
+        </div>
+
+        <ul id="cmd-results" class="cmd-results" role="listbox" aria-label="Search results" data-cmd-results>
+          {searchEntries.map((entry, index) => (
+            <li
+              id={`cmd-opt-${index}`}
+              class="cmd-result"
+              role="option"
+              aria-selected="false"
+              data-cmd-item
+              data-cmd-href={entry.href}
+              data-cmd-external={entry.external ? "true" : undefined}
+              data-cmd-text={`${entry.title} ${entry.category} ${entry.description} ${entry.terms}`.toLocaleLowerCase()}
+            >
+              <span class="chip">{entry.category}</span>
+              <span class="cmd-result-main">
+                <strong>{entry.title}</strong>
+                <span>{entry.description}</span>
+              </span>
+              {entry.external && <span class="result-meta">HexDocs ↗</span>}
+            </li>
+          ))}
+        </ul>
+
+        <p class="cmd-empty" hidden data-cmd-empty>
+          No matching docs — try a provider name, package name, or OAuth term.
+        </p>
+
+        <footer class="cmd-footer">
+          <span class="cmd-hint-keys"><kbd>↑</kbd><kbd>↓</kbd> navigate</span>
+          <span class="cmd-hint-keys"><kbd>↵</kbd> open</span>
+          <span class="cmd-hint-keys"><kbd>esc</kbd> close</span>
+          <span class="cmd-count" aria-live="polite" data-cmd-count></span>
+        </footer>
+      </div>
+    </dialog>
 
     <script is:inline>
       (() => {
@@ -332,6 +396,156 @@ const hasToc = toc.length > 0;
             }
           });
         }
+      })();
+    </script>
+
+    <script is:inline>
+      (() => {
+        const dialog = document.querySelector("[data-cmd-palette]");
+        if (!(dialog instanceof HTMLDialogElement) || typeof dialog.showModal !== "function") return;
+
+        const input = dialog.querySelector("[data-cmd-input]");
+        const list = dialog.querySelector("[data-cmd-results]");
+        const empty = dialog.querySelector("[data-cmd-empty]");
+        const count = dialog.querySelector("[data-cmd-count]");
+        if (!(input instanceof HTMLInputElement) || !list || !empty || !count) return;
+
+        const items = Array.from(dialog.querySelectorAll("[data-cmd-item]"));
+        const triggers = Array.from(document.querySelectorAll("[data-search-trigger]"));
+        let visible = items.slice();
+        let activeIndex = -1;
+        let activeEl = null;
+
+        const isMac = /mac|iphone|ipad|ipod/i.test(navigator.platform || navigator.userAgent || "");
+
+        // Progressive-enhancement hint: only show the shortcut when JS is live.
+        for (const trigger of document.querySelectorAll("[data-search-hint]")) {
+          const hint = document.createElement("kbd");
+          hint.className = "cmd-trigger-hint";
+          hint.setAttribute("aria-hidden", "true");
+          hint.textContent = isMac ? "\u2318K" : "Ctrl K";
+          trigger.append(hint);
+        }
+
+        const normalized = (value) =>
+          value
+            .toLocaleLowerCase()
+            .normalize("NFKD")
+            .replace(/[\u0300-\u036f]/g, "");
+
+        const setActive = (index) => {
+          if (activeEl) activeEl.setAttribute("aria-selected", "false");
+          activeIndex = index;
+          activeEl = index >= 0 ? visible[index] || null : null;
+          if (!activeEl) {
+            input.removeAttribute("aria-activedescendant");
+            return;
+          }
+          activeEl.setAttribute("aria-selected", "true");
+          input.setAttribute("aria-activedescendant", activeEl.id);
+          activeEl.scrollIntoView({ block: "nearest" });
+        };
+
+        const filter = () => {
+          const terms = normalized(input.value).trim().split(/\s+/).filter(Boolean);
+          visible = [];
+          for (const item of items) {
+            const text = normalized(item.dataset.cmdText || "");
+            const match = terms.every((term) => text.includes(term));
+            item.hidden = !match;
+            if (match) visible.push(item);
+          }
+          const n = visible.length;
+          count.textContent = `${n} result${n === 1 ? "" : "s"}`;
+          empty.hidden = n > 0;
+          list.hidden = n === 0;
+          setActive(n > 0 ? 0 : -1);
+        };
+
+        const openResult = (item) => {
+          if (!item) return;
+          const href = item.dataset.cmdHref;
+          if (!href) return;
+          close();
+          if (item.dataset.cmdExternal === "true") {
+            window.open(href, "_blank", "noopener,noreferrer");
+          } else {
+            window.location.assign(href);
+          }
+        };
+
+        const open = () => {
+          if (dialog.open) return;
+          input.value = "";
+          filter();
+          dialog.showModal();
+          input.focus();
+        };
+
+        const close = () => {
+          if (dialog.open) dialog.close();
+        };
+
+        for (const trigger of triggers) {
+          trigger.addEventListener("click", (event) => {
+            event.preventDefault();
+            open();
+          });
+        }
+
+        document.addEventListener("keydown", (event) => {
+          if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+            event.preventDefault();
+            dialog.open ? close() : open();
+            return;
+          }
+          if (event.key === "/" && !dialog.open && !event.metaKey && !event.ctrlKey && !event.altKey) {
+            const target = event.target;
+            const tag = target instanceof HTMLElement ? target.tagName : "";
+            const editable = target instanceof HTMLElement && target.isContentEditable;
+            if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || editable) return;
+            event.preventDefault();
+            open();
+          }
+        });
+
+        input.addEventListener("input", filter);
+
+        input.addEventListener("keydown", (event) => {
+          if (event.key === "ArrowDown") {
+            event.preventDefault();
+            if (visible.length) setActive((activeIndex + 1) % visible.length);
+          } else if (event.key === "ArrowUp") {
+            event.preventDefault();
+            if (visible.length) setActive((activeIndex - 1 + visible.length) % visible.length);
+          } else if (event.key === "Enter") {
+            event.preventDefault();
+            openResult(visible[activeIndex]);
+          } else if (event.key === "Home") {
+            if (visible.length) { event.preventDefault(); setActive(0); }
+          } else if (event.key === "End") {
+            if (visible.length) { event.preventDefault(); setActive(visible.length - 1); }
+          }
+        });
+
+        list.addEventListener("click", (event) => {
+          const target = event.target;
+          const item = target instanceof Element ? target.closest("[data-cmd-item]") : null;
+          if (item) openResult(item);
+        });
+
+        list.addEventListener("pointermove", (event) => {
+          const target = event.target;
+          const item = target instanceof Element ? target.closest("[data-cmd-item]") : null;
+          if (!item) return;
+          const i = visible.indexOf(item);
+          if (i >= 0 && i !== activeIndex) setActive(i);
+        });
+
+        // Click on the backdrop (the dialog element itself) closes it.
+        dialog.addEventListener("click", (event) => {
+          if (event.target === dialog) close();
+        });
       })();
     </script>
   </body>

--- a/website/src/pages/docs/[...slug].astro
+++ b/website/src/pages/docs/[...slug].astro
@@ -16,14 +16,17 @@ type Props = { entry: CollectionEntry<"docs"> };
 
 const { entry } = Astro.props;
 const { Content, headings } = await render(entry);
-const toc = entry.data.toc
-  ? headings
-      .filter((heading) => heading.depth === 2)
-      .map((heading) => ({
-        href: `#${heading.slug}`,
-        label: heading.text
-      }))
-  : [];
+const tocSetting = entry.data.toc;
+const toc = Array.isArray(tocSetting)
+  ? tocSetting
+  : tocSetting
+    ? headings
+        .filter((heading) => heading.depth === 2)
+        .map((heading) => ({
+          href: `#${heading.slug}`,
+          label: heading.text
+        }))
+    : [];
 ---
 
 <DocsLayout title={entry.data.title} description={entry.data.description} toc={toc}>

--- a/website/src/pages/docs/packages/[slug].astro
+++ b/website/src/pages/docs/packages/[slug].astro
@@ -1,6 +1,6 @@
 ---
-import { Code } from "astro:components";
 import type { CollectionEntry } from "astro:content";
+import CodeBlock from "../../../components/CodeBlock.astro";
 import DocsLayout from "../../../layouts/DocsLayout.astro";
 import {
   getPackageEntries,
@@ -32,9 +32,9 @@ const docsUrl = packageDocsUrl(pkg);
   toc={[
     { href: "#when-to-use", label: "When to use it" },
     { href: "#install", label: "Install" },
-    { href: "#setup", label: "Setup shape" },
+    { href: "#setup", label: "Setup" },
     { href: "#usage", label: "Usage" },
-    { href: "#handling", label: "Handling notes" }
+    { href: "#handling", label: "Responsibilities" }
   ]}
 >
   <article class="doc-page">
@@ -54,7 +54,7 @@ const docsUrl = packageDocsUrl(pkg);
       </div>
       <div id="install" class="install-card">
         <h2>Install</h2>
-        <Code code={data.install.join("\n")} lang="sh" themes={{ light: "catppuccin-latte", dark: "catppuccin-mocha" }} />
+        <CodeBlock code={data.install.join("\n")} lang="sh" />
         <nav class="resource-links" aria-label={`${data.name} package resources`}>
           <a href={hexUrl}>Hex package</a>
           <a href={docsUrl}>API docs</a>
@@ -63,7 +63,7 @@ const docsUrl = packageDocsUrl(pkg);
     </section>
 
     <section id="setup">
-      <h2>Setup shape</h2>
+      <h2>Setup</h2>
       <ol class="setup-list">
         {data.setup.map((item) => <li>{item}</li>)}
       </ol>
@@ -71,7 +71,7 @@ const docsUrl = packageDocsUrl(pkg);
 
     <section id="usage">
       <h2>Usage</h2>
-      <Code code={data.code} lang="gleam" themes={{ light: "catppuccin-latte", dark: "catppuccin-mocha" }} />
+      <CodeBlock code={data.code} lang="gleam" />
     </section>
 
     <section id="handling" class="content-grid">
@@ -82,7 +82,7 @@ const docsUrl = packageDocsUrl(pkg);
         </ul>
       </div>
       <div>
-        <h2>Notes to keep explicit</h2>
+        <h2>What you handle</h2>
         <ul class="check-list warning">
           {data.notes.map((item) => <li>{item}</li>)}
         </ul>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
-import { Code } from "astro:components";
 import { siApple, siGithub, siGoogle } from "simple-icons";
+import CodeBlock from "../components/CodeBlock.astro";
 import DocsLayout from "../layouts/DocsLayout.astro";
 import { getPackageEntries, packageHref, packageSlug } from "../data/content";
 
@@ -44,18 +44,27 @@ const supportedProviders = [
     icon: siApple
   }
 ];
-const directFlow = `let assert Ok(auth_request) = vestibule.create_authorization_request(strategy, cfg)
-// Store auth_request.state and auth_request.code_verifier.
-// Redirect to auth_request.url.
+const directFlow = `// Request phase: failure here means misconfiguration, so assert is fine.
+let assert Ok(auth_request) =
+  vestibule.create_authorization_request(strategy, cfg)
+// Store auth_request.state and auth_request.code_verifier, then
+// redirect to auth_request.url.
 
-let assert Ok(auth) =
+// Callback phase: state can mismatch and providers can reject the
+// user, so handle both branches instead of asserting.
+case
   vestibule.handle_callback(
     strategy,
     cfg,
     params,
     expected_state,
     code_verifier,
-  )`;
+  )
+{
+  Ok(auth) -> sign_in(auth)
+  Error(error.StateMismatch) -> restart_sign_in()
+  Error(reason) -> show_auth_error(reason)
+}`;
 ---
 
 <DocsLayout
@@ -113,7 +122,7 @@ let assert Ok(auth) =
         app needs Google, Microsoft, or Apple.
       </p>
     </div>
-    <Code code={directFlow} lang="gleam" class="code-card" themes={{ light: "catppuccin-latte", dark: "catppuccin-mocha" }} />
+    <CodeBlock code={directFlow} lang="gleam" class="code-card" />
   </section>
 
   <section aria-labelledby="supported-providers-heading">

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -854,7 +854,7 @@ pre code {
 
 :not(pre) > code {
   border: 1px solid var(--code-border);
-  border-radius: 0.3rem;
+  border-radius: var(--radius-sm);
   background: var(--code-bg);
   padding: 0.1rem 0.28rem;
 }
@@ -1135,7 +1135,7 @@ pre code {
 
 .path-body h2 {
   margin-top: var(--space-6);
-  font-size: var(--text-title);
+  font-size: var(--text-headline);
 }
 
 .path-body h2:first-child {
@@ -1707,5 +1707,255 @@ pre code {
 
   .content-shell {
     padding-top: var(--space-10);
+  }
+}
+
+/* Command palette (Cmd/Ctrl-K) — progressive enhancement over /docs/search */
+.cmd-trigger-hint {
+  margin-inline-start: var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--muted);
+  padding: 0.05rem 0.34rem;
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  font-weight: var(--weight-semibold);
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.cmd-palette {
+  width: min(38rem, calc(100vw - 2 * var(--space-4)));
+  max-width: calc(100vw - 2 * var(--space-4));
+  max-height: min(72vh, 38rem);
+  margin: 12vh auto auto;
+  padding: 0;
+  overflow: clip;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg);
+  color: var(--ink);
+  box-shadow: 0 24px 64px oklch(0.2 0.035 300 / 0.28);
+}
+
+:root[data-theme="dark"] .cmd-palette {
+  box-shadow: 0 24px 64px oklch(0 0 0 / 0.5);
+}
+
+.cmd-palette:focus-visible {
+  outline: none;
+  box-shadow: 0 24px 64px oklch(0.2 0.035 300 / 0.28);
+}
+
+.cmd-palette::backdrop {
+  background: color-mix(in oklch, var(--ink) 42%, transparent);
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
+}
+
+/* Open/close transition with reduced-motion fallback handled globally */
+.cmd-palette,
+.cmd-palette::backdrop {
+  transition:
+    opacity 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    transform 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    overlay 180ms allow-discrete,
+    display 180ms allow-discrete;
+}
+
+.cmd-palette[open] {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.cmd-palette:not([open]) {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+
+@starting-style {
+  .cmd-palette[open] {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+
+  .cmd-palette[open]::backdrop {
+    opacity: 0;
+  }
+}
+
+.cmd-palette-inner {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  max-height: inherit;
+}
+
+.cmd-search-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  border-bottom: 1px solid var(--border);
+  padding: var(--space-3) var(--space-4);
+}
+
+.cmd-search-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+  color: var(--muted);
+}
+
+.cmd-input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--ink);
+  padding: var(--space-2) 0;
+  font-size: var(--text-lead);
+}
+
+.cmd-input:focus {
+  outline: none;
+}
+
+.cmd-input::placeholder {
+  color: var(--muted);
+}
+
+.cmd-esc-hint {
+  flex-shrink: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--muted);
+  padding: 0.05rem 0.4rem;
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  font-weight: var(--weight-semibold);
+}
+
+.cmd-results {
+  display: grid;
+  gap: var(--space-1);
+  margin: 0;
+  overflow-y: auto;
+  padding: var(--space-2);
+  list-style: none;
+  overscroll-behavior: contain;
+}
+
+.cmd-result {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--space-3);
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-3);
+  cursor: pointer;
+}
+
+.cmd-result[aria-selected="true"] {
+  border-color: var(--primary);
+  background: var(--primary-soft);
+}
+
+.cmd-result .chip {
+  align-self: start;
+}
+
+.cmd-result-main {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.cmd-result-main strong {
+  color: var(--ink);
+  font-size: var(--text-body);
+  line-height: var(--line-title);
+  overflow-wrap: anywhere;
+}
+
+.cmd-result-main span {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: var(--text-label);
+  line-height: var(--line-compact);
+}
+
+.cmd-result .result-meta {
+  align-self: start;
+  white-space: nowrap;
+}
+
+.cmd-empty {
+  margin: 0;
+  padding: var(--space-6) var(--space-4);
+  color: var(--muted);
+  text-align: center;
+}
+
+.cmd-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-4);
+  align-items: center;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  padding: var(--space-2) var(--space-4);
+  color: var(--muted);
+  font-size: var(--text-caption);
+}
+
+.cmd-hint-keys {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.cmd-footer kbd {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  padding: 0.02rem 0.3rem;
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
+.cmd-count {
+  margin-inline-start: auto;
+  font-weight: var(--weight-semibold);
+}
+
+@media (max-width: 32rem) {
+  .cmd-palette {
+    width: 100%;
+    max-width: 100%;
+    max-height: 86vh;
+    margin: env(safe-area-inset-top) 0 0;
+    border-inline: 0;
+    border-block-start: 0;
+    border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  }
+}
+
+@media (forced-colors: active) {
+  .cmd-palette {
+    border-color: CanvasText;
+    box-shadow: none;
+  }
+
+  .cmd-result[aria-selected="true"] {
+    border-color: Highlight;
+    background: Canvas;
+    forced-color-adjust: none;
+    outline: 2px solid Highlight;
   }
 }


### PR DESCRIPTION
## Summary

Improves the documentation website (`website/`) across three dimensions — code-sample correctness, discoverability, and design-system consistency. Driven by an iterative design review; the design-health score moved **30 → 37 / 40**.

## Changes

### Correctness — harden OAuth examples
- Replaced every `let assert Ok(...)` in the primary copy-paste examples with `case`/`Ok`/`Error` handling (`index.astro`, `quick-start.mdx`, `packages/core.md`).
- Added a **"When the callback fails"** section that teaches the typed error variants (`StateMismatch`, `ProviderError`, `MissingCallbackParam`, transient failures), a safe generic user response, and a "do not leak the error" rule.

### Discoverability
- **Command palette** (`Cmd`/`Ctrl-K`, `/`): a native `<dialog>` global docs search reusing the existing `getSearchEntries()` data, with ARIA combobox/listbox semantics, keyboard nav, and the no-JS `/docs/search` page kept as a fallback.
- **Fixed empty in-page TOC** on MDX docs. Astro's `render()` only extracts markdown headings, so JSX `<h2>` pages rendered no "On this page" nav. Added an explicit frontmatter `toc` array option (boolean auto-extraction preserved as fallback) and curated TOCs for `quick-start` and `custom-strategy`.

### Design-system consistency
- Consolidated raw `<Code>` usages onto the shared `CodeBlock` wrapper (one theming path).
- Clarified abstract package labels (`Setup shape` → `Setup`, `Handling notes` → `Responsibilities`, `Notes to keep explicit` → `What you handle`).
- Restored in-panel heading hierarchy (`path-body h2`) and tokenized the inline-code radius.
- Synced `DESIGN.md` to the shipped neutral secondary button (honoring the Checkpoint Light Rule) and documented the modal-overlay shadow; registered the intentional Microsoft brand-square colors + modal shadow in `.impeccable/config.json`.

## Verification
- `pnpm build` green (13 pages).
- Command-palette behavior smoke-tested (open/filter/keyboard-nav/Enter-open/close), all paths passing.
- Design detector reports **0 findings**.
- Every TOC anchor verified against a real section `id`.

## Notes
- No library/runtime code changed — this is documentation-site only.
- Locally generated critique snapshots under `.impeccable/critique/` are intentionally **not** committed (review artifacts); only the shared detector config is included.
